### PR TITLE
Don't generate MonkeyLoader category outside of userspace

### DIFF
--- a/MonkeyLoader.Resonite.Integration/Configuration/SettingsDataFeedInjector.cs
+++ b/MonkeyLoader.Resonite.Integration/Configuration/SettingsDataFeedInjector.cs
@@ -373,12 +373,26 @@ namespace MonkeyLoader.Resonite.Configuration
             yield break;
         }
 
+        private static async IAsyncEnumerable<DataFeedItem> WorldNotUserspaceWarning(IReadOnlyList<string> path)
+        {
+            var warning = new DataFeedIndicator<string>();
+            warning.InitBase("Information", path, null, Mod.GetLocaleString("Information"));
+            warning.InitSetupValue(field => field.AssignLocaleString(Mod.GetLocaleKey("WorldNotUserspace").AsLocaleKey()));
+            yield return warning;
+        }
+
         [HarmonyPrefix]
         [HarmonyPatch(nameof(SettingsDataFeed.Enumerate))]
         private static bool EnumeratePrefix(SettingsDataFeed __instance, IReadOnlyList<string> path, ref IAsyncEnumerable<DataFeedItem> __result)
         {
             if (path.Count == 0 || path[0] != "MonkeyLoader")
                 return true;
+
+            if (!__instance.World.IsUserspace())
+            {
+                __result = WorldNotUserspaceWarning(path);
+                return false;
+            }
 
             if (path.Last() == SaveConfig)
             {

--- a/MonkeyLoader.Resonite.Integration/Locale/en.json
+++ b/MonkeyLoader.Resonite.Integration/Locale/en.json
@@ -16,6 +16,8 @@
     "MonkeyLoader.GamePacks.Resonite.Mod.Project": "Project",
     "MonkeyLoader.GamePacks.Resonite.Mod.Project.None": "<i>None</i>",
     "MonkeyLoader.GamePacks.Resonite.SaveConfig": "Save configuration to disk",
+    "MonkeyLoader.GamePacks.Resonite.Information": "Information",
+    "MonkeyLoader.GamePacks.Resonite.WorldNotUserspace": "This category is only accessible in userspace.",
 
     "MonkeyLoader.GamePacks.Resonite.Mod.OpenConfigSections": "Open available Settings",
     "Settings.ConfigSections.Breadcrumb": "Settings",


### PR DESCRIPTION
Prevents custom types from mods being added to the data model and potentially crashing people.

Closes #13 

![2024-05-04 16 50 41](https://github.com/ResoniteModdingGroup/MonkeyLoader.GamePacks.Resonite/assets/14206961/8ced56f0-04ab-497f-814c-87dda18977bd)