### PR TITLE
Move to generic DataFeedValueField template injection

### DIFF
--- a/MonkeyLoader.Resonite.Integration/Configuration/SettingsDataFeedInjector.cs
+++ b/MonkeyLoader.Resonite.Integration/Configuration/SettingsDataFeedInjector.cs
@@ -213,7 +213,7 @@ namespace MonkeyLoader.Resonite.Configuration
                     }
                     else
                     {
-                        Logger.Error(() => "InnerContainerItem slot is null in EnsurePrimitiveValueTemplate!");
+                        Logger.Error(() => "InnerContainerItem slot is null in EnsureDataFeedValueFieldTemplate!");
                     }
 
                     mapping.Template.Target = (FeedItemInterface)feedValueFieldInterface;
@@ -228,7 +228,7 @@ namespace MonkeyLoader.Resonite.Configuration
                 }
                 else
                 {
-                    Logger.Error(() => "Could not find Templates slot in EnsurePrimitiveValueTemplate!");
+                    Logger.Error(() => "Could not find Templates slot in EnsureDataFeedValueFieldTemplate!");
                 }
             }
             else

--- a/MonkeyLoader.Resonite.Integration/Configuration/SettingsDataFeedInjector.cs
+++ b/MonkeyLoader.Resonite.Integration/Configuration/SettingsDataFeedInjector.cs
@@ -671,9 +671,10 @@ namespace MonkeyLoader.Resonite.Configuration
             InitBase(valueField, path, configKey);
             valueField.InitSetupValue(field => field.SyncWithConfigKey(configKey, ConfigKeyChangeLabel));
 
-            if (GenericTypesAttribute.GetTypes(GenericTypesAttribute.Group.EnginePrimitives).Contains(typeof(T)) || typeof(T) == typeof(Type))
+            var valueType = typeof(T);
+            if (valueType != typeof(dummy) && (Coder<T>.IsEnginePrimitive || valueType == typeof(Type)))
             {
-                _cachedDataFeedItemMapper?.RunSynchronously(() => EnsureDataFeedValueFieldTemplate(_cachedDataFeedItemMapper, typeof(T)));
+                _cachedDataFeedItemMapper?.RunSynchronously(() => EnsureDataFeedValueFieldTemplate(_cachedDataFeedItemMapper, valueType));
             }
 
             return valueField;


### PR DESCRIPTION
This will generate DataFeedValueField templates using SyncMemberEditorBuilder.Build for any engine primitive type or Type type as needed

Closes https://github.com/ResoniteModdingGroup/MonkeyLoader.GamePacks.Resonite/issues/26

![2024-06-01 15 20 30](https://github.com/ResoniteModdingGroup/MonkeyLoader.GamePacks.Resonite/assets/14206961/af7d61cb-3edd-4b83-b5ad-1aeba0ed4186)