### PR TITLE
Reset field value if config key set fails

### DIFF
--- a/MonkeyLoader.Resonite.Integration/Configuration/ConfigKeySessionShare.cs
+++ b/MonkeyLoader.Resonite.Integration/Configuration/ConfigKeySessionShare.cs
@@ -156,10 +156,10 @@ namespace MonkeyLoader.Resonite.Configuration
 
         private void SharedValueChanged(SyncField<T> field)
         {
-            if (AllowWriteBack)
-                _configKey.SetValue(field.Value, $"{SharedConfig.WriteBackPrefix}.{field.World.GetIdentifier()}");
-            else
+            if (!AllowWriteBack || !_configKey.TrySetValue(field.Value, $"{SharedConfig.WriteBackPrefix}.{field.World.GetIdentifier()}"))
+            {
                 field.World.RunSynchronously(() => field.Value = _configKey.GetValue()!);
+            }
         }
 
         private void ValueChanged(object sender, ConfigKeyChangedEventArgs<T> configKeyChangedEventArgs)

--- a/MonkeyLoader.Resonite.Integration/FieldExtensions.cs
+++ b/MonkeyLoader.Resonite.Integration/FieldExtensions.cs
@@ -19,10 +19,10 @@ namespace MonkeyLoader.Resonite
             void FieldChangedHandler(IChangeable _)
             {
                 if (field.Value.Equals(configKey.GetValue())) return;
-                if (allowWriteBack)
-                    configKey.SetValue(field.Value, eventLabel);
-                else
+                if (!(allowWriteBack && configKey.TrySetValue(field.Value, eventLabel)))
+                {
                     field.World.RunSynchronously(() => field.Value = configKey.GetValue()!);
+                }
             }
             void ConfigKeyChangedHandler(object sender, ConfigKeyChangedEventArgs<T> args)
             {

--- a/MonkeyLoader.Resonite.Integration/FieldExtensions.cs
+++ b/MonkeyLoader.Resonite.Integration/FieldExtensions.cs
@@ -19,7 +19,7 @@ namespace MonkeyLoader.Resonite
             void FieldChangedHandler(IChangeable _)
             {
                 if (field.Value.Equals(configKey.GetValue())) return;
-                if (!(allowWriteBack && configKey.TrySetValue(field.Value, eventLabel)))
+                if (!allowWriteBack || !configKey.TrySetValue(field.Value, eventLabel))
                 {
                     field.World.RunSynchronously(() => field.Value = configKey.GetValue()!);
                 }


### PR DESCRIPTION
If the config key set fails maybe because of a valueValidator or some other error, reset the field value back to the config key's value