### PR TITLE
Makes ConfigKeySessionShare components more resilient against deletion of their Slot and add conversion layer

### DIFF
--- a/MonkeyLoader.Resonite.Integration/Configuration/ConfigKeySessionShare.cs
+++ b/MonkeyLoader.Resonite.Integration/Configuration/ConfigKeySessionShare.cs
@@ -1,8 +1,10 @@
-﻿using FrooxEngine;
+﻿using Elements.Core;
+using FrooxEngine;
 using MonkeyLoader.Components;
 using MonkeyLoader.Configuration;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -12,22 +14,28 @@ namespace MonkeyLoader.Resonite.Configuration
 {
     /// <summary>
     /// Represents a wrapper for an <see cref="IDefiningConfigKey{T}"/>,
-    /// which makes its local value available as a shared resource in Resonite sessions.<br/>
-    /// Optionally allows writing back changes from the session to the config item.
+    /// which makes its local value available as a (converted) shared resource in Resonite <see cref="World"/>s.<br/>
+    /// Optionally allows writing back changes from the <see cref="World"/> to the config item.
     /// </summary>
-    /// <typeparam name="T">The type of the config item's value.</typeparam>
-    public sealed class ConfigKeySessionShare<T> : IConfigKeySessionShare<T>
+    /// <typeparam name="TKey">The type of the config item's value.</typeparam>
+    /// <typeparam name="TShared">
+    /// The type of the resource shared in Resonite <see cref="World"/>s.
+    /// Must be a valid generic parameter for <see cref="ValueField{T}"/> components.
+    /// </typeparam>
+    public class ConfigKeySessionShare<TKey, TShared> : IConfigKeySessionShare<TKey, TShared>
     {
+        private readonly Converter<TShared?, TKey?> _convertToKey;
+        private readonly Converter<TKey?, TShared?> _convertToShared;
         private readonly Lazy<string> _sharedId;
         private readonly Lazy<string> _variableName;
-        private IDefiningConfigKey<T> _configKey = null!;
-        private T? _defaultValue;
+        private IDefiningConfigKey<TKey> _configKey = null!;
+        private TShared? _defaultValue;
 
         /// <inheritdoc/>
         public bool AllowWriteBack { get; set; }
 
         /// <inheritdoc/>
-        public T? DefaultValue
+        public TShared? DefaultValue
         {
             get => _defaultValue;
             set
@@ -45,7 +53,7 @@ namespace MonkeyLoader.Resonite.Configuration
         object? IConfigKeySessionShare.DefaultValue
         {
             get => DefaultValue;
-            set => DefaultValue = (T?)value;
+            set => DefaultValue = (TShared)value!;
         }
 
         /// <inheritdoc/>
@@ -59,16 +67,39 @@ namespace MonkeyLoader.Resonite.Configuration
         /// which makes its config key's local value available as a shared resource in Resonite sessions.<br/>
         /// Optionally allows writing back changes from the session to the config item.
         /// </summary>
-        /// <param name="defaultValue">The default value for the shared config item for users that don't have it themselves.</param>
+        /// <param name="convertToShared">Converts the config item's value to the shared resource's.</param>
+        /// <param name="convertToKey">Converts the shared resource's value to the config item's.</param>
+        /// <param name="defaultValue">
+        /// The default value for the shared config item for users that don't have it themselves.<br/>
+        /// Gets converted to <typeparamref name="TShared"/> using <paramref name="convertToShared"/>.
+        /// </param>
         /// <param name="allowWriteBack">Whether to allow writing back changes from the session to the config item.</param>
-        public ConfigKeySessionShare(T? defaultValue = default, bool allowWriteBack = false)
+        /// <exception cref="InvalidOperationException">When <typeparamref name="TShared"/> is an invalid generic argument for <see cref="ValueField{T}"/> components.</exception>
+        public ConfigKeySessionShare(Converter<TKey?, TShared?> convertToShared, Converter<TShared?, TKey?> convertToKey,
+            TKey? defaultValue = default, bool allowWriteBack = false)
         {
-            _defaultValue = defaultValue;
+            if (!typeof(ValueField<TShared>).IsValidGenericType(true))
+                throw new InvalidOperationException("TShared must be a valid generic argument for ValueField<T> components!");
+
+            _convertToShared = convertToShared;
+            _convertToKey = convertToKey;
+
+            _defaultValue = convertToShared(defaultValue);
             AllowWriteBack = allowWriteBack;
 
             _sharedId = new(() => $"{SharedConfig.Identifier}.{_configKey!.FullId}");
             _variableName = new(() => $"World/{SharedId}");
         }
+
+        /// <inheritdoc/>
+        public TKey? ConvertToKey(TShared? sharedValue) => _convertToKey(sharedValue);
+
+        object? IConfigKeySessionShare.ConvertToKey(object? sharedValue) => _convertToKey((TShared?)sharedValue);
+
+        /// <inheritdoc/>
+        public TShared? ConvertToShared(TKey? keyValue) => _convertToShared(keyValue);
+
+        object? IConfigKeySessionShare.ConvertToShared(object? keyValue) => _convertToShared((TKey?)keyValue);
 
         /// <summary>
         /// Creates a <see cref="ValueCopy{T}"/> on the given <paramref name="field"/>'s
@@ -81,7 +112,7 @@ namespace MonkeyLoader.Resonite.Configuration
         /// </param>
         /// <returns>The created <see cref="ValueCopy{T}"/> component.</returns>
         /// <exception cref="InvalidOperationException">When <paramref name="writeBack"/> is <c>true</c> and <see cref="AllowWriteBack">AllowWriteBack</see> isn't.</exception>
-        public ValueCopy<T> Drive(IField<T> field, bool writeBack = false)
+        public ValueCopy<TShared> Drive(IField<TShared> field, bool writeBack = false)
         {
             if (!AllowWriteBack && writeBack)
                 throw new InvalidOperationException("Can't enable write back on a drive if it's not enabled for the config item!");
@@ -91,12 +122,22 @@ namespace MonkeyLoader.Resonite.Configuration
 
         /// <summary>
         /// Creates a <see cref="DynamicValueVariableDriver{T}"/> on the given <paramref name="field"/>'s
-        /// parent <see cref="Slot"/>, which drives it from the shared value.
+        /// parent <see cref="Slot"/>, which drives it from the shared value.<br/>
+        /// The driver's <see cref="DynamicValueVariableDriver{T}.DefaultValue">DefaultValue</see>
+        /// is set to the shared value's <see cref="DefaultValue">DefaultValue</see>.
         /// </summary>
         /// <param name="field">The field to drive with the shared value.</param>
         /// <returns>The created <see cref="DynamicValueVariableDriver{T}"/> component.</returns>
-        public DynamicValueVariableDriver<T> DriveFromVariable(IField<T> field)
-            => field.DriveFromVariable(VariableName);
+        public DynamicValueVariableDriver<TShared> DriveFromVariable(IField<TShared> field)
+        {
+            // Get Shared Value to ensure that the necessary components exist
+            GetSharedValue(field.World);
+
+            var driver = field.DriveFromVariable(VariableName);
+            driver.DefaultValue.Value = DefaultValue!;
+
+            return driver;
+        }
 
         /// <summary>
         /// Gets this shared config item's <see cref="Slot"/> under the
@@ -113,7 +154,7 @@ namespace MonkeyLoader.Resonite.Configuration
                 .Select(valueOverride => valueOverride.Value.User.Target)
                 .Where(user => user is not null);
 
-        void IComponent<IDefiningConfigKey<T>>.Initialize(IDefiningConfigKey<T> entity)
+        void IComponent<IDefiningConfigKey<TKey>>.Initialize(IDefiningConfigKey<TKey> entity)
         {
             _configKey = entity;
             entity.Changed += ValueChanged;
@@ -129,34 +170,34 @@ namespace MonkeyLoader.Resonite.Configuration
         public void ShutdownOverride(World world)
             => world.RunSynchronously(() => GetSharedValue(world).Value.OnValueChange -= SharedValueChanged);
 
-        private ValueUserOverride<T> GetSharedOverride(World world)
+        private ValueUserOverride<TShared> GetSharedOverride(World world)
             => GetSharedValue(world).Value.GetUserOverride();
 
-        private ValueField<T> GetSharedValue(World world)
-            => world.GetSharedComponentOrCreate<ValueField<T>>(SharedId, SetupSharedField, 0, true, false, () => GetSharedConfigSlot(world));
+        private ValueField<TShared> GetSharedValue(World world)
+            => world.GetSharedComponentOrCreate<ValueField<TShared>>(SharedId, SetupSharedField, 0, true, false, () => GetSharedConfigSlot(world));
 
-        private void SetupSharedField(ValueField<T> field)
+        private void SetupSharedField(ValueField<TShared> field)
         {
-            if (!field.IsDriven && EqualityComparer<T>.Default.Equals(field.Value, default!))
+            if (!field.IsDriven && EqualityComparer<TShared>.Default.Equals(field.Value, default!))
                 field.Value.Value = DefaultValue!;
 
             field.Value.GetSyncWithVariable(VariableName);
 
-            var vuo = field.Value.OverrideForUser(field.World.LocalUser, _configKey.GetValue()!);
+            var vuo = field.Value.OverrideForUser(field.World.LocalUser, ConvertToShared(_configKey.GetValue())!);
             vuo.CreateOverrideOnWrite.Value = true;
 
             field.Value.OnValueChange += SharedValueChanged;
         }
 
-        private void SharedValueChanged(SyncField<T> field)
+        private void SharedValueChanged(SyncField<TShared> field)
         {
-            if (!AllowWriteBack || !_configKey.TrySetValue(field.Value, $"{SharedConfig.WriteBackPrefix}.{field.World.GetIdentifier()}"))
+            if (!AllowWriteBack || !_configKey.TrySetValue(ConvertToKey(field.Value)!, $"{SharedConfig.WriteBackPrefix}.{field.World.GetIdentifier()}"))
             {
-                field.World.RunSynchronously(() => field.Value = _configKey.GetValue()!);
+                field.World.RunSynchronously(() => field.Value = ConvertToShared(_configKey.GetValue())!);
             }
         }
 
-        private void ValueChanged(object sender, ConfigKeyChangedEventArgs<T> configKeyChangedEventArgs)
+        private void ValueChanged(object sender, ConfigKeyChangedEventArgs<TKey> configKeyChangedEventArgs)
         {
             if (Engine.Current?.WorldManager is null)
                 return;
@@ -164,8 +205,31 @@ namespace MonkeyLoader.Resonite.Configuration
             configKeyChangedEventArgs.TryGetWorldIdentifier(out var worldIdentifier);
 
             foreach (var world in Engine.Current.WorldManager.Worlds.Where(world => world.GetIdentifier() != worldIdentifier))
-                world.RunSynchronously(() => GetSharedValue(world).Value.Value = configKeyChangedEventArgs.NewValue!);
+                world.RunSynchronously(() => GetSharedValue(world).Value.Value = ConvertToShared(configKeyChangedEventArgs.NewValue)!);
         }
+    }
+
+    /// <summary>
+    /// Represents a wrapper for an <see cref="IDefiningConfigKey{T}"/>,
+    /// which makes its local value available as a shared resource in Resonite <see cref="World"/>s.<br/>
+    /// Optionally allows writing back changes from the <see cref="World"/> to the config item.
+    /// </summary>
+    /// <typeparam name="T">The type of the config item's value.</typeparam>
+    public sealed class ConfigKeySessionShare<T> : ConfigKeySessionShare<T, T>, IConfigKeySessionShare<T>
+    {
+        /// <summary>
+        /// Creates a new <see cref="IConfigKeySessionShare{T}"/> component,
+        /// which makes its config key's local value available as a shared resource in Resonite sessions.<br/>
+        /// Optionally allows writing back changes from the session to the config item.
+        /// </summary>
+        /// <param name="defaultValue">The default value for the shared config item for users that don't have it themselves.</param>
+        /// <param name="allowWriteBack">Whether to allow writing back changes from the session to the config item.</param>
+        public ConfigKeySessionShare(T? defaultValue = default!, bool allowWriteBack = false)
+            : base(Identity, Identity, defaultValue, allowWriteBack)
+        { }
+
+        [return: NotNullIfNotNull(nameof(item))]
+        private static T? Identity(T? item) => item;
     }
 
     /// <summary>
@@ -197,6 +261,26 @@ namespace MonkeyLoader.Resonite.Configuration
         public string VariableName { get; }
 
         /// <summary>
+        /// Converts the given value from the shared resource's type to the config item's.
+        /// </summary>
+        /// <remarks>
+        /// May throw when the provided input isn't compatible.
+        /// </remarks>
+        /// <param name="sharedValue">The value suitable for the shared resource to be converted.</param>
+        /// <returns>The value converted to the config item's type.</returns>
+        public object? ConvertToKey(object? sharedValue);
+
+        /// <summary>
+        /// Converts the given value from the config item's type to the shared resource's.
+        /// </summary>
+        /// <remarks>
+        /// May throw when the provided input isn't compatible.
+        /// </remarks>
+        /// <param name="keyValue">The value suitable for the config item to be converted.</param>
+        /// <returns>The value converted to the shared resource's type.</returns>
+        public object? ConvertToShared(object? keyValue);
+
+        /// <summary>
         /// Gets a sequence of users who have defined overrides for the shared value.
         /// </summary>
         /// <param name="world">The world to get the sharing users for.</param>
@@ -220,15 +304,45 @@ namespace MonkeyLoader.Resonite.Configuration
 
     /// <summary>
     /// Defines the interface for config key components,
-    /// which make the key's local value available as a shared resource in Resonite sessions,
-    /// and optionally allow writing back changes from the session to the config item.
+    /// which make the key's local value available as a shared resource in Resonite <see cref="World"/>s,
+    /// and optionally allow writing back changes from the <see cref="World"/> to the config item.
     /// </summary>
-    /// <typeparam name="T">The type of the config item's value.</typeparam>
-    public interface IConfigKeySessionShare<T> : IConfigKeyComponent<IDefiningConfigKey<T>>, IConfigKeySessionShare
+    /// <typeparam name="TKey">The type of the config item's value.</typeparam>
+    /// <typeparam name="TShared">The type of the resource shared in Resonite <see cref="World"/>s.</typeparam>
+    public interface IConfigKeySessionShare<TKey, TShared> : IConfigKeyComponent<IDefiningConfigKey<TKey>>, IConfigKeySessionShare
     {
         /// <summary>
         /// Gets or sets the default value for the shared config item for users that don't have it themselves.
         /// </summary>
-        public new T? DefaultValue { get; set; }
+        public new TShared? DefaultValue { get; set; }
+
+        /// <summary>
+        /// Converts the given value from the shared resource's type to the config item's.
+        /// </summary>
+        /// <remarks>
+        /// May throw when the provided input isn't compatible.
+        /// </remarks>
+        /// <param name="sharedValue">The value suitable for the shared resource to be converted.</param>
+        /// <returns>The value converted to the config item's type.</returns>
+        public TKey? ConvertToKey(TShared? sharedValue);
+
+        /// <summary>
+        /// Converts the given value from the config item's type to the shared resource's.
+        /// </summary>
+        /// <remarks>
+        /// May throw when the provided input isn't compatible.
+        /// </remarks>
+        /// <param name="keyValue">The value suitable for the config item to be converted.</param>
+        /// <returns>The value converted to the shared resource's type.</returns>
+        public TShared? ConvertToShared(TKey? keyValue);
     }
+
+    /// <summary>
+    /// Defines the interface for config key components,
+    /// which make the key's local value available as a shared resource in Resonite sessions,
+    /// and optionally allow writing back changes from the session to the config item.
+    /// </summary>
+    /// <typeparam name="T">The type of the config item's value and the resource shared in Resonite <see cref="World"/>.</typeparam>
+    public interface IConfigKeySessionShare<T> : IConfigKeySessionShare<T, T>
+    { }
 }

--- a/MonkeyLoader.Resonite.Integration/UI/DefaultInspectorHeaderConfig.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/DefaultInspectorHeaderConfig.cs
@@ -7,31 +7,30 @@ namespace MonkeyLoader.Resonite.UI
     /// <summary>
     /// Represents the config for the <see cref="DefaultInspectorHeaderHandler"/>.
     /// </summary>
-    // No Ranges because there's no long slider :C
     public sealed class DefaultInspectorHeaderConfig : SingletonConfigSection<DefaultInspectorHeaderConfig>
     {
-        private static readonly DefiningConfigKey<long> _destroyOffset = new("DestroyOffset", "The Order Offset of the Destroy button on Inspector Headers. Range: 0-16 - Higher is further right.", () => 12, valueValidator: ValidateRange)
+        private static readonly DefiningConfigKey<int> _destroyOffset = new("DestroyOffset", "The Order Offset of the Destroy button on Inspector Headers. Range: 0-16 - Higher is further right.", () => 12, valueValidator: ValidateRange)
         {
-            // new ConfigKeyRange<long>(0, 16),
-            new ConfigKeySessionShare<long>(12)
+            new ConfigKeyRange<int>(0, 16),
+            new ConfigKeySessionShare<int, long>(IntToLong, LongToInt, 12)
         };
 
-        private static readonly DefiningConfigKey<long> _duplicateOffset = new("DuplicateOffset", "The Order Offset of the Duplicate button on Inspector Headers. Range: 0-16 - Higher is further right.", () => 11, valueValidator: ValidateRange)
+        private static readonly DefiningConfigKey<int> _duplicateOffset = new("DuplicateOffset", "The Order Offset of the Duplicate button on Inspector Headers. Range: 0-16 - Higher is further right.", () => 11, valueValidator: ValidateRange)
         {
-            // new ConfigKeyRange<long>(0, 16),
-            new ConfigKeySessionShare<long>(11)
+            new ConfigKeyRange<int>(0, 16),
+            new ConfigKeySessionShare<int, long>(IntToLong, LongToInt, 11)
         };
 
-        private static readonly DefiningConfigKey<long> _openContainerOffset = new("OpenContainerOffset", "The Order Offset of the Open Container button on Inspector Headers. Range: 0-16 - Higher is further right.", () => 4, valueValidator: ValidateRange)
+        private static readonly DefiningConfigKey<int> _openContainerOffset = new("OpenContainerOffset", "The Order Offset of the Open Container button on Inspector Headers. Range: 0-16 - Higher is further right.", () => 4, valueValidator: ValidateRange)
         {
-            // new ConfigKeyRange<long>(0, 16),
-            new ConfigKeySessionShare<long>(10)
+            new ConfigKeyRange<int>(0, 16),
+            new ConfigKeySessionShare<int, long>(IntToLong, LongToInt, 10)
         };
 
-        private readonly DefiningConfigKey<long> _workerNameOffset = new("NameOffset", "The Order Offset of the Worker Name button on Inspector Headers. Range: 0-16 - Higher is further right.", () => 6, valueValidator: ValidateRange)
+        private readonly DefiningConfigKey<int> _workerNameOffset = new("NameOffset", "The Order Offset of the Worker Name button on Inspector Headers. Range: 0-16 - Higher is further right.", () => 6, valueValidator: ValidateRange)
         {
-            // new ConfigKeyRange<long>(0, 16),
-            new ConfigKeySessionShare<long>(6)
+            new ConfigKeyRange<int>(0, 16),
+            new ConfigKeySessionShare<int, long>(IntToLong, LongToInt, 6)
         };
 
         /// <inheritdoc/>
@@ -40,12 +39,12 @@ namespace MonkeyLoader.Resonite.UI
         /// <summary>
         /// Gets the Order Offset share for the Destroy button on Inspector Headers.
         /// </summary>
-        public ConfigKeySessionShare<long> DestroyOffset => _destroyOffset.Components.Get<ConfigKeySessionShare<long>>();
+        public ConfigKeySessionShare<int, long> DestroyOffset => _destroyOffset.Components.Get<ConfigKeySessionShare<int, long>>();
 
         /// <summary>
         /// Gets the Order Offset share for the Duplicate button on Inspector Headers.
         /// </summary>
-        public ConfigKeySessionShare<long> DuplicateOffset => _duplicateOffset.Components.Get<ConfigKeySessionShare<long>>();
+        public ConfigKeySessionShare<int, long> DuplicateOffset => _duplicateOffset.Components.Get<ConfigKeySessionShare<int, long>>();
 
         /// <inheritdoc/>
         public override string Id => "DefaultInspectorHeader";
@@ -53,17 +52,21 @@ namespace MonkeyLoader.Resonite.UI
         /// <summary>
         /// Gets the Order Offset share for the Open Container button on Inspector Headers.
         /// </summary>
-        public ConfigKeySessionShare<long> OpenContainerOffset => _openContainerOffset.Components.Get<ConfigKeySessionShare<long>>();
+        public ConfigKeySessionShare<int, long> OpenContainerOffset => _openContainerOffset.Components.Get<ConfigKeySessionShare<int, long>>();
 
         /// <inheritdoc/>
-        public override Version Version { get; } = new Version(1, 0, 0);
+        public override Version Version { get; } = new Version(1, 0, 1);
 
         /// <summary>
         /// Gets the Order Offset share for the Worker Name button on Inspector Headers.
         /// </summary>
-        public ConfigKeySessionShare<long> WorkerNameOffset => _workerNameOffset.Components.Get<ConfigKeySessionShare<long>>();
+        public ConfigKeySessionShare<int, long> WorkerNameOffset => _workerNameOffset.Components.Get<ConfigKeySessionShare<int, long>>();
 
-        private static bool ValidateRange(long value)
-                                                                    => value is >= 0 and <= 16;
+        private static long IntToLong(int value) => value;
+
+        private static int LongToInt(long value) => (int)value;
+
+        private static bool ValidateRange(int value)
+            => value is >= 0 and <= 16;
     }
 }

--- a/MonkeyLoader.Resonite.Integration/UI/DefaultInspectorHeaderHandler.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/DefaultInspectorHeaderHandler.cs
@@ -32,7 +32,7 @@ namespace MonkeyLoader.Resonite.UI
                 button.Slot.AttachComponent<ReferenceProxySource>().Reference.Target = worker;
                 button.Label.Color.Value = RadiantUI_Constants.LABEL_COLOR;
 
-                ConfigSection.WorkerNameOffset.Drive(button.Slot._orderOffset);
+                ConfigSection.WorkerNameOffset.DriveFromVariable(button.Slot._orderOffset);
             }
 
             ui.PushStyle();
@@ -42,7 +42,7 @@ namespace MonkeyLoader.Resonite.UI
             if (eventData.CreateOpenContainerButton)
             {
                 var button = ui.ButtonRef(OfficialAssets.Graphics.Icons.Inspector.RootUp, RadiantUI_Constants.Sub.PURPLE, eventData.Inspector.OnOpenContainerPressed, worker);
-                ConfigSection.OpenContainerOffset.Drive(button.Slot._orderOffset);
+                ConfigSection.OpenContainerOffset.DriveFromVariable(button.Slot._orderOffset);
 
                 eventData.HasOpenContainerButton = true;
             }
@@ -50,7 +50,7 @@ namespace MonkeyLoader.Resonite.UI
             if (eventData.CreateDuplicateButton)
             {
                 var button = ui.ButtonRef(OfficialAssets.Graphics.Icons.Inspector.Duplicate, RadiantUI_Constants.Sub.GREEN, eventData.Inspector.OnDuplicateComponentPressed, worker);
-                ConfigSection.DuplicateOffset.Drive(button.Slot._orderOffset);
+                ConfigSection.DuplicateOffset.DriveFromVariable(button.Slot._orderOffset);
 
                 eventData.HasDuplicateButton = true;
             }
@@ -58,7 +58,7 @@ namespace MonkeyLoader.Resonite.UI
             if (eventData.CreateDestroyButton)
             {
                 var button = ui.ButtonRef(OfficialAssets.Graphics.Icons.Inspector.Destroy, RadiantUI_Constants.Sub.RED, eventData.Inspector.OnRemoveComponentPressed, worker);
-                ConfigSection.DestroyOffset.Drive(button.Slot._orderOffset);
+                ConfigSection.DestroyOffset.DriveFromVariable(button.Slot._orderOffset);
 
                 eventData.HasDestroyButton = true;
             }


### PR DESCRIPTION
This makes it so all the necessary components get restored if the value field is missing.
It also adds a conversion layer so that an `int` config key (has a slider settings item) can be used to create a `long` (doesn't have a fancy settings item) shared value to drive an OrderOffset for example. 