### PR TITLE
Fix null exception in tooltip button delegate handler

### DIFF
--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/ButtonDelegateTooltipResolver.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/ButtonDelegateTooltipResolver.cs
@@ -47,6 +47,8 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
                 return;
             }
 
+            if (pressed.Method is null) return;
+
             var targetType = pressed.Method.GetMethodInfo().DeclaringType;
             var localeKey = $"Tooltip.{targetType.Name}.{pressed.MethodName}";
 

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/ButtonDelegateTooltipResolver.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/ButtonDelegateTooltipResolver.cs
@@ -29,7 +29,8 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
                 pressed = eventData.Button.Pressed;
             }
             else if (eventData.Button.Slot.GetComponent<ButtonRelayBase>() is ButtonRelayBase relay
-             && relay.GetSyncMember(nameof(ButtonRelay<dummy>.ButtonPressed)) is ISyncDelegate relayPressed)
+             && relay.GetSyncMember(nameof(ButtonRelay<dummy>.ButtonPressed)) is ISyncDelegate relayPressed
+             && relayPressed.Method is not null)
             {
                 pressed = relayPressed;
 
@@ -46,8 +47,6 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
             {
                 return;
             }
-
-            if (pressed.Method is null) return;
 
             var targetType = pressed.Method.GetMethodInfo().DeclaringType;
             var localeKey = $"Tooltip.{targetType.Name}.{pressed.MethodName}";


### PR DESCRIPTION
I saw this error is someone's log, the method was null, so add a check for that

The log https://discord.com/channels/901126079857692714/1320694896335519808/1320733737440247908