### PR TITLE
Update hyperlink tooltips with optional additional data

### DIFF
--- a/MonkeyLoader.Resonite.Integration/Locale/de.json
+++ b/MonkeyLoader.Resonite.Integration/Locale/de.json
@@ -75,6 +75,7 @@
     "MonkeyLoader.GamePacks.Resonite.ResoniteLogToConsole.Description": "Sendet die FrooxEngine UniLog Nachrichten an die MonkeyLoader Konsole, falls diese verfügbar ist.",
     "MonkeyLoader.GamePacks.Resonite.DataFeedInjectors.SettingsDataFeed.Description": "Sorgt dafür, dass Elemente in den SettingsDataFeed injiziert werden können.<br/>Dieser Injektor kann nicht deaktiviert werden, um sicherzustellen, dass die MonkeyLoader Einstellungen verfügbar bleiben.",
 
-    "MonkeyLoader.GamePacks.Resonite.Tooltip.OpenHyperlink": "Versucht einen Hyperlink zu öffnen.<br/><b>Grund:</b> <i>{reason}</i><br/><b>URL:</b> <i>{url}</i>"
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.OpenHyperlink.Direct": "Versucht einen Hyperlink zu öffnen.<size=50%><br/><br/></size><b>Grund:</b> <i>{reason}</i><br/><b>URL:</b> <i>{url}</i>",
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.OpenHyperlink.WithLabel": "{label}<size=50%><br/><br/></size><b>Grund:</b> <i>{reason}</i><br/><b>URL:</b> <i>{url}</i>"
   }
 }

--- a/MonkeyLoader.Resonite.Integration/Locale/en.json
+++ b/MonkeyLoader.Resonite.Integration/Locale/en.json
@@ -100,6 +100,7 @@
 
     "MonkeyLoader.GamePacks.Resonite.OpenLinkedDynamicVariableSpace.Description": "Adds buttons to dynamic variable components to open the linked space.",
 
-    "MonkeyLoader.GamePacks.Resonite.Tooltip.OpenHyperlink": "Attempts to open a hyperlink.<br/><b>Reason:</b> <i>{reason}</i><br/><b>URL:</b> <i>{url}</i>"
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.OpenHyperlink.Direct": "Attempts to open a hyperlink.<size=50%><br/><br/></size><b>Reason:</b> <i>{reason}</i><br/><b>URL:</b> <i>{url}</i>",
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.OpenHyperlink.WithLabel": "{label}<size=50%><br/><br/></size><b>Reason:</b> <i>{reason}</i><br/><b>URL:</b> <i>{url}</i>"
   }
 }

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/HyperlinkTooltipResolver.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/HyperlinkTooltipResolver.cs
@@ -14,23 +14,44 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
     /// </summary>
     public sealed class HyperlinkTooltipResolver : ResoniteCancelableEventHandlerMonkey<HyperlinkTooltipResolver, ResolveTooltipLabelEvent>
     {
+        /// <summary>
+        /// The key used for the <see cref="LocaleString.content"/> on label-<see cref="LocaleString"/>s,
+        /// when the existing label <see cref="LocaleString.isLocaleKey">is not a locale key</see>.
+        /// </summary>
+        public const string LabelArg = "label";
+
+        /// <summary>
+        /// The key used for the <see cref="Hyperlink.Reason"/> on label-<see cref="LocaleString"/>s.
+        /// </summary>
+        public const string ReasonArg = "reason";
+
+        /// <summary>
+        /// The key used for the <see cref="Hyperlink.URL"/> on label-<see cref="LocaleString"/>s.
+        /// </summary>
+        public const string UrlArg = "url";
+
         /// <inheritdoc/>
         public override bool CanBeDisabled => true;
 
         /// <inheritdoc/>
-        public override int Priority => HarmonyLib.Priority.Low;
+        public override int Priority => HarmonyLib.Priority.VeryLow;
 
         /// <inheritdoc/>
-        public override bool SkipCanceled => true;
+        public override bool SkipCanceled => !TooltipConfig.Instance.ShowExtendedTooltipForHyperlinks;
 
         /// <summary>
         /// Tries to find a <see cref="Hyperlink"/> on the <paramref name="button"/>'s <see cref="Slot"/>
         /// and extracts the tooltip label from its <see cref="Hyperlink.Reason">reason</see> for opening.
         /// </summary>
+        /// <remarks>
+        /// If an <paramref name="existingLabel"/> is set, the hyperlink information will be added to it if present.<br/>
+        /// If the <paramref name="existingLabel"/> is already a hyperlink label, it will be used.
+        /// </remarks>
         /// <param name="button">The button component next to which a <see cref="Hyperlink"/> will be searched.</param>
         /// <param name="label">The found label if a suitable Hyperlink is found; otherwise, <c>null</c>.</param>
+        /// <param name="existingLabel">The optional label already existing for this button.</param>
         /// <returns><c>true</c> if a suitable <see cref="Hyperlink"/> was found; otherwise, <c>false</c>.</returns>
-        public static bool TryGetTooltipLabel(IButton button, [NotNullWhen(true)] out LocaleString? label)
+        public static bool TryGetTooltipLabel(IButton button, [NotNullWhen(true)] out LocaleString? label, LocaleString? existingLabel = default)
         {
             if (button.Slot.GetComponent<Hyperlink>() is not Hyperlink hyperlink)
             {
@@ -38,16 +59,37 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
                 return false;
             }
 
-            var reason = hyperlink.Reason ?? "None Given";
-            label = Mod.GetLocaleString("Tooltip.OpenHyperlink", ("reason", reason), ("url", hyperlink.URL.Value));
+            var reason = hyperlink.Reason ?? "null";
+            var url = hyperlink.URL.Value?.ToString() ?? "null";
 
-            return label is not null;
+            if (!existingLabel.HasValue)
+            {
+                label = Mod.GetLocaleString("Tooltip.OpenHyperlink.Direct", (ReasonArg, reason), (UrlArg, url));
+                return true;
+            }
+
+            var exLabel = existingLabel.Value;
+
+            if (exLabel.arguments.ContainsKey(ReasonArg) && exLabel.arguments.ContainsKey(UrlArg))
+            {
+                label = exLabel;
+                return true;
+            }
+
+            if (exLabel.isLocaleKey)
+            {
+                label = new(exLabel.content, $"{exLabel.format ?? "{0}"}<size=50%><br/><br/></size><i>{reason}<br/>{url}</i>", true, exLabel.isContinuous, exLabel.arguments);
+                return true;
+            }
+
+            label = Mod.GetLocaleString("Tooltip.OpenHyperlink.WithLabel", (LabelArg, exLabel.content), (ReasonArg, reason), (UrlArg, url));
+            return true;
         }
 
         /// <inheritdoc/>
         protected override void Handle(ResolveTooltipLabelEvent eventData)
         {
-            if (TryGetTooltipLabel(eventData.Button, out var label))
+            if (TryGetTooltipLabel(eventData.Button, out var label, eventData.Label))
                 eventData.Label = label;
         }
     }

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/TooltipConfig.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/TooltipConfig.cs
@@ -22,6 +22,7 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
             new ConfigKeyQuantity<float, Time>(new UnitConfiguration("s", "0", " ", ["s", "ms"]), null, 0, 2)
         };
 
+        private static readonly DefiningConfigKey<bool> _showExtendedTooltipForHyperlinks = new("ShowExtendedTooltipForHyperlinks", "When enabled, a Hyperlink component's reason and URL are always shown in tooltips.", () => false);
         private static readonly DefiningConfigKey<colorX> _textColorKey = new("TextColor", "Sets the text color of a tooltip.", () => RadiantUI_Constants.TEXT_COLOR);
 
         private static readonly DefiningConfigKey<float> _textScaleKey = new("TextSize", "Sets the size of the text on a tooltip.", () => 1f)
@@ -60,6 +61,11 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
 
         /// <inheritdoc/>
         public override string Id => "Tooltips";
+
+        /// <summary>
+        /// Gets whether a Hyperlink component's reason and URL are always shown in tooltips.
+        /// </summary>
+        public bool ShowExtendedTooltipForHyperlinks => _showExtendedTooltipForHyperlinks;
 
         /// <summary>
         /// Gets the text color for tooltips.


### PR DESCRIPTION
Always displays the reason and url when only the hyperlink label is present.

Optionally (based on setting) adds the reason and url to other labels.