### PR TITLE
Add Helpers for settings DataFeed

### DIFF
--- a/MonkeyLoader.Resonite.Integration/DataFeeds/DataFeedInjector.cs
+++ b/MonkeyLoader.Resonite.Integration/DataFeeds/DataFeedInjector.cs
@@ -30,6 +30,7 @@ namespace MonkeyLoader.Resonite.DataFeeds
         {
             Builder = new();
             Builder.AddBuildingBlock(new OriginalDataFeedResultBuildingBlock<TDataFeed>());
+
             DataFeedInjectorManager.AddInjector<DataFeedInjector<TDataFeed>>();
         }
 
@@ -60,7 +61,7 @@ namespace MonkeyLoader.Resonite.DataFeeds
         private static IAsyncEnumerable<DataFeedItem> EnumeratePostfix(IAsyncEnumerable<DataFeedItem> __result, TDataFeed __instance, IReadOnlyList<string> __0, IReadOnlyList<string> __1, string __2, object __3)
         {
             // I hate having to use the __n syntax for Arguments, but Froox can't decide whether to use groupKeys or groupingKeys
-            // The method signature is based on an interface anyways, so the argument names can be whatever - better be save than sorry
+            // The method signature is based on an interface anyways, so the argument names can be whatever - better be safe than sorry
 
             if (!Enabled)
                 return __result;

--- a/MonkeyLoader.Resonite.Integration/DataFeeds/Settings/ConfigSectionSettingsItems.cs
+++ b/MonkeyLoader.Resonite.Integration/DataFeeds/Settings/ConfigSectionSettingsItems.cs
@@ -28,7 +28,7 @@ namespace MonkeyLoader.Resonite.DataFeeds.Settings
         private static readonly MethodInfo _generateNullableEnumItemsAsync = AccessTools.Method(typeof(ConfigSectionSettingsItems), nameof(GenerateNullableEnumItemsAsync));
         private static readonly MethodInfo _generateQuantityField = AccessTools.Method(typeof(ConfigSectionSettingsItems), nameof(GenerateQuantityField));
 
-        public override int Priority => 400;
+        public override int Priority => HarmonyLib.Priority.Normal;
 
         public override IAsyncEnumerable<DataFeedItem> Apply(IAsyncEnumerable<DataFeedItem> current, EnumerateDataFeedParameters<SettingsDataFeed> parameters)
         {

--- a/MonkeyLoader.Resonite.Integration/DataFeeds/Settings/ModMetadataSettingsItems.cs
+++ b/MonkeyLoader.Resonite.Integration/DataFeeds/Settings/ModMetadataSettingsItems.cs
@@ -13,7 +13,7 @@ namespace MonkeyLoader.Resonite.DataFeeds.Settings
 {
     internal sealed class ModMetadataSettingsItems : DataFeedBuildingBlockMonkey<ModMetadataSettingsItems, SettingsDataFeed>
     {
-        public override int Priority => 200;
+        public override int Priority => HarmonyLib.Priority.Low;
 
         public override IAsyncEnumerable<DataFeedItem> Apply(IAsyncEnumerable<DataFeedItem> current, EnumerateDataFeedParameters<SettingsDataFeed> parameters)
         {

--- a/MonkeyLoader.Resonite.Integration/DataFeeds/Settings/MonkeyLoaderRootCategorySettingsItems.cs
+++ b/MonkeyLoader.Resonite.Integration/DataFeeds/Settings/MonkeyLoaderRootCategorySettingsItems.cs
@@ -20,7 +20,7 @@ namespace MonkeyLoader.Resonite.DataFeeds.Settings
     [HarmonyPatchCategory(nameof(MonkeyLoaderRootCategorySettingsItems))]
     internal sealed class MonkeyLoaderRootCategorySettingsItems : DataFeedBuildingBlockMonkey<MonkeyLoaderRootCategorySettingsItems, SettingsDataFeed>
     {
-        public override int Priority => 200;
+        public override int Priority => HarmonyLib.Priority.Low;
 
         public override IAsyncEnumerable<DataFeedItem> Apply(IAsyncEnumerable<DataFeedItem> current, EnumerateDataFeedParameters<SettingsDataFeed> parameters)
         {

--- a/MonkeyLoader.Resonite.Integration/DataFeeds/Settings/SaveConfigSettingsItems.cs
+++ b/MonkeyLoader.Resonite.Integration/DataFeeds/Settings/SaveConfigSettingsItems.cs
@@ -13,7 +13,7 @@ namespace MonkeyLoader.Resonite.DataFeeds.Settings
 {
     internal sealed class SaveConfigSettingsItems : DataFeedBuildingBlockMonkey<SaveConfigSettingsItems, SettingsDataFeed>
     {
-        public override int Priority => 300;
+        public override int Priority => HarmonyLib.Priority.LowerThanNormal;
 
         public override IAsyncEnumerable<DataFeedItem> Apply(IAsyncEnumerable<DataFeedItem> current, EnumerateDataFeedParameters<SettingsDataFeed> parameters)
         {
@@ -40,7 +40,7 @@ namespace MonkeyLoader.Resonite.DataFeeds.Settings
                         Logger.Info(() => $"Triggering saving of config: {config.FullId}");
 
                         config.Save();
-                        MoveUpFromCategory(parameters);
+                        parameters.MoveUpFromCategory();
 
                         return current;
 
@@ -48,7 +48,7 @@ namespace MonkeyLoader.Resonite.DataFeeds.Settings
                         Logger.Info(() => $"Triggering reset of config: {config.FullId}");
 
                         config.Reset();
-                        MoveUpFromCategory(parameters);
+                        parameters.MoveUpFromCategory();
 
                         return current;
                 }
@@ -69,15 +69,12 @@ namespace MonkeyLoader.Resonite.DataFeeds.Settings
             await Task.CompletedTask;
 
             var saveConfigButton = new DataFeedCategory();
-            saveConfigButton.InitBase(SettingsHelpers.SaveConfig, parameters.Path, parameters.GroupKeys, Mod.GetLocaleString("SaveConfig"));
+            saveConfigButton.InitBase(SettingsHelpers.SaveConfig, parameters.Path, parameters.GroupKeys, Mod.GetLocaleString(SettingsHelpers.SaveConfig));
             yield return saveConfigButton;
 
             var resetConfigButton = new DataFeedCategory();
-            resetConfigButton.InitBase(SettingsHelpers.ResetConfig, parameters.Path, parameters.GroupKeys, Mod.GetLocaleString("ResetConfig"));
+            resetConfigButton.InitBase(SettingsHelpers.ResetConfig, parameters.Path, parameters.GroupKeys, Mod.GetLocaleString(SettingsHelpers.ResetConfig));
             yield return resetConfigButton;
         }
-
-        private static void MoveUpFromCategory(EnumerateDataFeedParameters<SettingsDataFeed> parameters)
-            => parameters.DataFeed.RunSynchronously(() => parameters.DataFeed.GetViewData().MoveUpFromCategory(parameters.Path[^1]));
     }
 }

--- a/MonkeyLoader.Resonite.Integration/DataFeeds/Settings/SettingsHelpers.cs
+++ b/MonkeyLoader.Resonite.Integration/DataFeeds/Settings/SettingsHelpers.cs
@@ -206,6 +206,37 @@ namespace MonkeyLoader.Resonite.DataFeeds.Settings
         public static bool IsInjectableEditorType<T>() => IsInjectableEditorType(typeof(T));
 
         /// <summary>
+        /// Move up one element from the current path of the <see cref="EnumerateDataFeedParameters{TDataFeed}.DataFeed">DataFeed</see>.
+        /// </summary>
+        /// <param name="parameters">The parameters referencing the <see cref="SettingsDataFeed"/> to move up a category on.</param>
+        public static void MoveUpFromCategory(this EnumerateDataFeedParameters<SettingsDataFeed> parameters)
+            => parameters.DataFeed.RunSynchronously(() => parameters.DataFeed.GetViewData().MoveUpFromCategory(parameters.Path[^1]));
+
+        /// <summary>
+        /// Handles the standard case of setting up the field of a <see cref="DataFeedItem"/>
+        /// to be synchronized with a <see cref="IDefiningConfigKey{T}">config key</see>.
+        /// </summary>
+        /// <remarks>
+        /// Adds a <see cref="Comment"/> with the <paramref name="configKey"/>.<see cref="IIdentifiable.FullId">FullId</see>
+        /// to allow easily mapping it back to the config key in the standalone facet process.
+        /// </remarks>
+        /// <typeparam name="T">The type of the field and config item's value.</typeparam>
+        /// <param name="field">The field to synchronize with the <paramref name="configKey"/>.</param>
+        /// <param name="configKey">The config key to synchronize with the <paramref name="field"/>.</param>
+        public static void SetupConfigKeyField<T>(this IField<T> field, IDefiningConfigKey<T> configKey)
+        {
+            var slot = field.FindNearestParent<Slot>();
+
+            if (slot.GetComponentInParents<FeedItemInterface>() is FeedItemInterface feedItemInterface)
+            {
+                // Adding the config key's full id to make it easier to create standalone facets
+                feedItemInterface.Slot.AttachComponent<Comment>().Text.Value = configKey.FullId;
+            }
+
+            field.SyncWithConfigKey(configKey, ConfigKeyChangeLabel);
+        }
+
+        /// <summary>
         /// Handles the standard case of setting up the field of a <see cref="DataFeedItem"/>
         /// to be synchronized with a <see cref="IDefiningConfigKey{T}">config key</see>.
         /// </summary>


### PR DESCRIPTION
Wanted to add more refactoring to the way that the settings paths are matched (using [Generex](https://github.com/Banane9/Generex)), but we can include this for a release already.