### PR TITLE
Reenable InstantResoniteLog and make it proxy for UniLog.FlushEveryMessage

### DIFF
--- a/MonkeyLoader.Resonite.Integration/InstantResoniteLog.cs
+++ b/MonkeyLoader.Resonite.Integration/InstantResoniteLog.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using Elements.Core;
+using HarmonyLib;
 using MonkeyLoader.Patching;
 using System;
 using System.Collections.Generic;
@@ -8,16 +9,22 @@ using System.Threading.Tasks;
 
 namespace MonkeyLoader.Resonite
 {
-    [HarmonyPatchCategory(nameof(InstantResoniteLog))]
-    [HarmonyPatch("FrooxEngineBootstrap+<>c, Assembly-CSharp", "<Start>b__10_1")]
-    internal class InstantResoniteLog : Monkey<InstantResoniteLog>
+    internal sealed class InstantResoniteLog : Monkey<InstantResoniteLog>
     {
+        public override bool CanBeDisabled => true;
+
         public override string Name { get; } = "Instant Resonite Log";
 
-        protected override IEnumerable<IFeaturePatch> GetFeaturePatches() => Enumerable.Empty<IFeaturePatch>();
+        protected override bool OnComputeDefaultEnabledState()
+            => false;
 
-        [HarmonyPostfix]
-        private static void WriteLinePostfix()
-            => FrooxEngineBootstrap.LogStream.Flush();
+        protected override void OnDisabled()
+            => UniLog.FlushEveryMessage = false;
+
+        protected override void OnEnabled()
+            => UniLog.FlushEveryMessage = true;
+
+        protected override bool OnLoaded()
+            => UniLog.FlushEveryMessage = Enabled;
     }
 }

--- a/MonkeyLoader.Resonite.Integration/Locale/de.json
+++ b/MonkeyLoader.Resonite.Integration/Locale/de.json
@@ -72,6 +72,7 @@
     "MonkeyLoader.GamePacks.Resonite.ButtonTooltips.Description": "Fügt Tooltip Auflösungsanfragen für UIX Buttons hinzu.",
     "MonkeyLoader.GamePacks.Resonite.CommentTooltipResolver.Description": "Löst die Anfrage für den Tooltip eines Buttons auf, indem es nach einer Comment Komponente sucht, deren Text mit 'TooltipperyLabel:' anfängt.",
     "MonkeyLoader.GamePacks.Resonite.TooltipManager.Description": "Versendet die Tooltip Auflösungsanfragen aus verschiedenen Quellen. Das Tooltipsystem basiert auf dem Tooltippery Mod, der ursprünglich von Psychpsyo erstellt wurde.",
+    "MonkeyLoader.GamePacks.Resonite.InstantResoniteLog.Description": "Steuert die Einstellung dafür, jede Nachricht im Resonite Log sofort zu schreiben, indem es den eigenen Aktivierungszustand damit synchronisiert.",
     "MonkeyLoader.GamePacks.Resonite.ResoniteLogToConsole.Description": "Sendet die FrooxEngine UniLog Nachrichten an die MonkeyLoader Konsole, falls diese verfügbar ist.",
     "MonkeyLoader.GamePacks.Resonite.DataFeedInjectors.SettingsDataFeed.Description": "Sorgt dafür, dass Elemente in den SettingsDataFeed injiziert werden können.<br/>Dieser Injektor kann nicht deaktiviert werden, um sicherzustellen, dass die MonkeyLoader Einstellungen verfügbar bleiben.",
 

--- a/MonkeyLoader.Resonite.Integration/Locale/en.json
+++ b/MonkeyLoader.Resonite.Integration/Locale/en.json
@@ -89,6 +89,7 @@
     "MonkeyLoader.GamePacks.Resonite.ButtonTooltips.Description": "Adds tooltip resolve requests to UIX Buttons.",
     "MonkeyLoader.GamePacks.Resonite.CommentTooltipResolver.Description": "Resolves the tooltip for a button based on a Comment component's text starting with 'TooltipperyLabel:'.",
     "MonkeyLoader.GamePacks.Resonite.TooltipManager.Description": "Sends out tooltip resolve requests from different sources. The tooltip system is based on the Tooltippery mod originally created by Psychpsyo.",
+    "MonkeyLoader.GamePacks.Resonite.InstantResoniteLog.Description": "Controls the option to immediately flush every message in Resonite's log by proxying its enabled state to it.",
     "MonkeyLoader.GamePacks.Resonite.ResoniteLogToConsole.Description": "Sends the FrooxEngine UniLog messages to the MonkeyLoader Console when available.",
     "MonkeyLoader.GamePacks.Resonite.DataFeedInjectors.SettingsDataFeed.Description": "Handles injecting elements into the SettingsDataFeed.<br/>This injector can't be disabled to ensure that the MonkeyLoader settings remain available.",
     "MonkeyLoader.GamePacks.Resonite.MonkeyLoaderRootCategorySettingsItems.Name": "Root Category Settings Items",

--- a/MonkeyLoader.Resonite.Integration/MonkeyLoader.Resonite.Integration.csproj
+++ b/MonkeyLoader.Resonite.Integration/MonkeyLoader.Resonite.Integration.csproj
@@ -37,11 +37,6 @@
   </Target>
 
   <ItemGroup>
-    <Compile Remove="InstantResoniteLog.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="InstantResoniteLog.cs" />
     <None Include="..\README.md" Pack="true" PackagePath="" />
     <None Include="..\Icon.png" Pack="true" PackagePath="" />
     <None Include="Locale\*.json" Pack="true" PackagePath="content/Locale/" />
@@ -58,9 +53,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Resonite.Elements.Assets" Version="1.3.3" />
-    <PackageReference Include="Resonite.Elements.Core" Version="1.4.3" />
+    <PackageReference Include="Resonite.Elements.Core" Version="1.4.8.1" />
     <PackageReference Include="Resonite.Elements.Quantity" Version="1.2.3" />
-    <PackageReference Include="Resonite.FrooxEngine" Version="2025.5.33.1285" />
+    <PackageReference Include="Resonite.FrooxEngine" Version="2025.6.9.1085" />
     <PackageReference Include="Resonite.FrooxEngine.Store" Version="1.0.5" />
     <PackageReference Include="Resonite.FrooxEngine.Weaver" Version="1.0.5" />
     <PackageReference Include="Resonite.LiteDB" Version="5.0.20" />


### PR DESCRIPTION
This allows that option to be controlled when debugging things or trying to evaluate issues.