### PR TITLE
Some prerelease fixes

### DIFF
--- a/MonkeyLoader.Resonite.Integration/MonkeyLoader.Resonite.Integration.csproj
+++ b/MonkeyLoader.Resonite.Integration/MonkeyLoader.Resonite.Integration.csproj
@@ -52,12 +52,12 @@ Additionally it contains many useful features for Users and Developers alike.</D
     <PackageReference Include="Resonite.Elements.Assets" Version="1.3.3" />
     <PackageReference Include="Resonite.Elements.Core" Version="1.4.8.3" />
     <PackageReference Include="Resonite.Elements.Quantity" Version="1.2.3" />
-    <PackageReference Include="Resonite.FrooxEngine" Version="2025.7.14.1289" />
+    <PackageReference Include="Resonite.FrooxEngine" Version="2025.8.20.613" />
     <PackageReference Include="Resonite.FrooxEngine.Store" Version="1.0.5" />
     <PackageReference Include="Resonite.FrooxEngine.Weaver" Version="1.0.5" />
     <PackageReference Include="Resonite.LiteDB" Version="5.0.20" />
     <PackageReference Include="Resonite.LiteDB.Async" Version="0.1.10" />
-    <PackageReference Include="Resonite.Renderite.Shared" Version="1.0.0" />
+    <PackageReference Include="Renderite.Renderer.Renderite.Shared" Version="1.1.2" />
     <PackageReference Include="Resonite.SkyFrost.Base" Version="2.1.0" />
     <PackageReference Include="Resonite.SkyFrost.Base.Models" Version="2.1.5" />
   </ItemGroup>

--- a/MonkeyLoaderWrapper/MonkeyLoaderWrapper.csproj
+++ b/MonkeyLoaderWrapper/MonkeyLoaderWrapper.csproj
@@ -4,16 +4,15 @@
     <TargetFramework>net9.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PublishSingleFile>true</PublishSingleFile>
+    <PublishSingleFile>false</PublishSingleFile>
     <UseWindowsForms>true</UseWindowsForms>
     <AssemblyFileName>$(AssemblyTitle).dll</AssemblyFileName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonkeyLoader" Version="0.27.1-beta" />
     <PackageReference Include="System.Management" Version="9.0.6" />
   </ItemGroup>
-
+    
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(CopyToLibraries)'=='true'">
     <Copy SourceFiles="$(TargetDir)$(TargetFileName)" DestinationFiles="$(ResonitePath)/$(TargetFileName)" />
     <Message Text="Copied $(TargetFileName) to $(ResonitePath)/$(AssemblyFileName)" Importance="high" />

--- a/MonkeyLoaderWrapper/Program.cs
+++ b/MonkeyLoaderWrapper/Program.cs
@@ -1,39 +1,51 @@
-﻿using HarmonyLib;
-using MonkeyLoader.NuGet;
-using NuGet.Packaging.Core;
-using NuGet.Versioning;
+﻿using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.Loader;
 
 internal class Program
 {
     private static readonly FileInfo _monkeyLoaderPath = new(Path.Combine("MonkeyLoader", "MonkeyLoader.dll"));
 
     private static readonly FileInfo _resonitePath = new("Resonite.dll");
-
-    static Program()
-    {
-        // This ONLY applies to ML assemblies, so what is required to run ML. We don't want to load anything else with this handler.
-        AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
-        {
-            var name = args.Name.Split(',')[0];
-
-            var mlPath = Path.Combine(_monkeyLoaderPath.DirectoryName!, $"{name}.dll");
-            if (File.Exists(mlPath))
-                return Assembly.LoadFile(mlPath);
-
-            return null;
-        };
-    }
-
+    
+    private static object? _monkeyLoaderInstance = null;
+    private static MethodInfo? _monkeyLoaderResolveAssemblyMethod = null;
+    
     private static async Task Main(string[] args)
     {
-        var monkeyLoader = new MonkeyLoader.MonkeyLoader();
-        monkeyLoader.FullLoad();
+        var loadContext = new MonkeyLoaderAssemblyLoadContext(_monkeyLoaderPath.DirectoryName!, (assemblyName) =>
+        {
+            if (_monkeyLoaderInstance == null || _monkeyLoaderResolveAssemblyMethod == null)
+                return null;
+            
+            // Attempt to resolve the assembly using MonkeyLoader's method
+            var resolvedAssembly = _monkeyLoaderResolveAssemblyMethod.Invoke(_monkeyLoaderInstance, [assemblyName]);
+            if (resolvedAssembly is Assembly assembly)
+            {
+                Debug.WriteLine("=> Resolved assembly: " + assembly.FullName);
+                return assembly;
+            }
 
-        var resoniteAssembly = Assembly.LoadFile(_resonitePath.FullName);
+            return null;
+        });
+        loadContext.Resolving += (context, assembly)
+            => throw new Exception("This should never happen, we need to know about all assemblies ahead of time through ML");
+        
+        var monkeyLoaderAssembly = loadContext.LoadFromAssemblyPath(_monkeyLoaderPath.FullName);
+        
+        var monkeyLoaderType = monkeyLoaderAssembly.GetType("MonkeyLoader.MonkeyLoader");
+        var loggingLevelType = monkeyLoaderAssembly.GetType("MonkeyLoader.Logging.LoggingLevel");
+        var traceLogLevel = Enum.Parse(loggingLevelType!, "Trace");
 
-        // If we had the game and ML in a load context, this would not be necessary since it can resolve native libraries with a generic callback
+        _monkeyLoaderInstance = Activator.CreateInstance(monkeyLoaderType!, traceLogLevel, "MonkeyLoader/MonkeyLoader.json");
+        _monkeyLoaderResolveAssemblyMethod = monkeyLoaderType!.GetMethod("ResolveAssemblyFromPoolsAndMods", BindingFlags.Public | BindingFlags.Instance);
+        var fullLoadMethod = monkeyLoaderType!.GetMethod("FullLoad", BindingFlags.Public | BindingFlags.Instance); 
+        fullLoadMethod!.Invoke(_monkeyLoaderInstance!, null);
+
+        var resoniteAssembly = loadContext.LoadFromAssemblyPath(_resonitePath.FullName);
+
+        // TODO: Should not be necessary anymore with the hookfxr changes. Either way, should be done by the load context
         NativeLibrary.SetDllImportResolver(resoniteAssembly, ResolveNativeLibrary);
         NativeLibrary.SetDllImportResolver(AppDomain.CurrentDomain.GetAssemblies().First(x => x.FullName!.Contains("SteamAudio.NET")), ResolveNativeLibrary);
 
@@ -41,8 +53,6 @@ internal class Program
 
         if (mainResult is Task task)
             await task;
-
-        return;
     }
 
     private static IntPtr ResolveNativeLibrary(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
@@ -56,5 +66,33 @@ internal class Program
             return NativeLibrary.Load(libraryPath);
 
         return IntPtr.Zero;
+    }
+}
+
+internal class MonkeyLoaderAssemblyLoadContext(
+    string monkeyLoaderPath,
+    MonkeyLoaderAssemblyLoadContext.AssemblyResolveEventHandler handler)
+    : AssemblyLoadContext("MonkeyLoader")
+{
+    public delegate Assembly? AssemblyResolveEventHandler(AssemblyName assemblyName);
+    
+    private readonly AssemblyResolveEventHandler? _assemblyResolveEventHandler = handler;
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        Debug.WriteLine($"MonkeyLoaderAssemblyLoadContext: Resolving {assemblyName.FullName}");
+        if (_assemblyResolveEventHandler != null)
+        {
+            var resolvedAssembly = _assemblyResolveEventHandler(assemblyName);
+            if (resolvedAssembly != null)
+            {
+                Debug.WriteLine($"=> Resolved assembly: {resolvedAssembly.FullName}");
+                return resolvedAssembly;
+            }
+        }
+        
+        var name = assemblyName.Name;
+        var mlPath = Path.Combine(monkeyLoaderPath, $"{name}.dll");
+        return File.Exists(mlPath) ? LoadFromAssemblyPath(mlPath) : null;
     }
 }


### PR DESCRIPTION
Fixes compatibility with the current prerelease, and adds support for the assembly load context work I did in [this PR](https://github.com/MonkeyModdingTroop/MonkeyLoader/pull/71) which prevents us from loading multiple instances of the same assembly, or multiple assemblies of different versions, which currently crashes the game when scanning datamodel types.