### PR TITLE
Fix a bug in CustomInspectorInjector, and a design change

### DIFF
--- a/MonkeyLoader.Resonite.Integration/UI/Inspectors/CustomInspectorInjector.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Inspectors/CustomInspectorInjector.cs
@@ -38,8 +38,7 @@ namespace MonkeyLoader.Resonite.UI.Inspectors
 
                 OnBuildInspectorHeader(ui, __instance, worker, allowContainer, allowDuplicate, allowRemove, memberFilter);
 
-                if (ui.Root != vertical.Slot)
-                    ui.NestInto(vertical.Slot);
+                ui.NestOut();
             }
 
             OnBuildInspectorHeaderText(ui, worker);
@@ -74,43 +73,27 @@ namespace MonkeyLoader.Resonite.UI.Inspectors
         private static void OnBuildInspectorBody(UIBuilder ui, WorkerInspector inspector, Worker worker,
             bool allowContainer, bool allowDuplicate, bool allowDestroy, Predicate<ISyncMember> memberFilter)
         {
-            var root = ui.Root;
-
             var eventData = new BuildInspectorBodyEvent(ui, inspector, worker, allowContainer, allowDuplicate, allowDestroy, memberFilter);
 
             Dispatch(eventData);
-
-            if (ui.Root != root)
-                ui.NestInto(root);
         }
 
         private static void OnBuildInspectorHeader(UIBuilder ui, WorkerInspector inspector, Worker worker,
             bool allowContainer, bool allowDuplicate, bool allowDestroy, Predicate<ISyncMember> memberFilter)
         {
-            var root = ui.Root;
-
             var eventData = new BuildInspectorHeaderEvent(ui, inspector, worker, allowContainer, allowDuplicate, allowDestroy, memberFilter);
 
             Dispatch(eventData);
-
-            if (ui.Root != root)
-                ui.NestInto(root);
         }
 
         private static void OnBuildInspectorHeaderText(UIBuilder ui, Worker worker)
         {
-            var root = ui.Root;
-
             var eventData = new ResolveInspectorHeaderTextEvent(worker);
 
             Dispatch(eventData);
 
             if (eventData.ItemCount is 0)
-            {
-                if (ui.Root != root)
-                    ui.NestInto(root);
                 return;
-            }
 
             // The expander code is based on SlotInspector.OnChanges
 
@@ -164,9 +147,8 @@ namespace MonkeyLoader.Resonite.UI.Inspectors
             }
 
             ui.PopStyle();
-
-            if (ui.Root != root)
-                ui.NestInto(root);
+            ui.NestOut(); // nest out of textLayout, into childrenLayout
+            ui.NestOut(); // nest out of childrenLayout, into whatever it was before this method was called
         }
     }
 }

--- a/MonkeyLoader.Resonite.Integration/UI/Inspectors/CustomInspectorInjector.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Inspectors/CustomInspectorInjector.cs
@@ -38,7 +38,8 @@ namespace MonkeyLoader.Resonite.UI.Inspectors
 
                 OnBuildInspectorHeader(ui, __instance, worker, allowContainer, allowDuplicate, allowRemove, memberFilter);
 
-                ui.NestInto(vertical.Slot);
+                if (ui.Root != vertical.Slot)
+                    ui.NestInto(vertical.Slot);
             }
 
             OnBuildInspectorHeaderText(ui, worker);
@@ -79,7 +80,8 @@ namespace MonkeyLoader.Resonite.UI.Inspectors
 
             Dispatch(eventData);
 
-            ui.NestInto(root);
+            if (ui.Root != root)
+                ui.NestInto(root);
         }
 
         private static void OnBuildInspectorHeader(UIBuilder ui, WorkerInspector inspector, Worker worker,
@@ -91,21 +93,26 @@ namespace MonkeyLoader.Resonite.UI.Inspectors
 
             Dispatch(eventData);
 
-            ui.NestInto(root);
+            if (ui.Root != root)
+                ui.NestInto(root);
         }
 
         private static void OnBuildInspectorHeaderText(UIBuilder ui, Worker worker)
         {
+            var root = ui.Root;
+
             var eventData = new ResolveInspectorHeaderTextEvent(worker);
 
             Dispatch(eventData);
 
             if (eventData.ItemCount is 0)
+            {
+                if (ui.Root != root)
+                    ui.NestInto(root);
                 return;
+            }
 
             // The expander code is based on SlotInspector.OnChanges
-
-            var root = ui.Root;
 
             ui.PushStyle();
             ui.Style.MinHeight = 32;
@@ -157,7 +164,9 @@ namespace MonkeyLoader.Resonite.UI.Inspectors
             }
 
             ui.PopStyle();
-            ui.NestInto(root);
+
+            if (ui.Root != root)
+                ui.NestInto(root);
         }
     }
 }

--- a/MonkeyLoader.Resonite.Integration/UI/Inspectors/DefaultInspectorHeaderHandler.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Inspectors/DefaultInspectorHeaderHandler.cs
@@ -32,31 +32,34 @@ namespace MonkeyLoader.Resonite.UI.Inspectors
                 eventData.WorkerNameButton = button;
             }
 
-            ui.Style.FlexibleWidth = 0;
-            ui.Style.MinWidth = 40;
-
-            if (eventData.CreateOpenContainerButton)
+            if (eventData.AllowDestroy || eventData.AllowDuplicate || eventData.AllowContainer) // match vanilla
             {
-                var button = ui.ButtonRef(OfficialAssets.Graphics.Icons.Inspector.RootUp, RadiantUI_Constants.Sub.PURPLE, eventData.Inspector.OnOpenContainerPressed, worker);
-                ConfigSection.OpenContainerOffset.DriveFromVariable(button.Slot._orderOffset);
+                ui.Style.FlexibleWidth = 0;
+                ui.Style.MinWidth = 40;
 
-                eventData.OpenContainerButton = button;
-            }
+                if (eventData.CreateOpenContainerButton)
+                {
+                    var button = ui.ButtonRef(OfficialAssets.Graphics.Icons.Inspector.RootUp, RadiantUI_Constants.Sub.PURPLE, eventData.Inspector.OnOpenContainerPressed, worker);
+                    ConfigSection.OpenContainerOffset.DriveFromVariable(button.Slot._orderOffset);
 
-            if (eventData.CreateDuplicateButton)
-            {
-                var button = ui.ButtonRef(OfficialAssets.Graphics.Icons.Inspector.Duplicate, RadiantUI_Constants.Sub.GREEN, eventData.Inspector.OnDuplicateComponentPressed, worker);
-                ConfigSection.DuplicateOffset.DriveFromVariable(button.Slot._orderOffset);
+                    eventData.OpenContainerButton = button;
+                }
 
-                eventData.DuplicateButton = button;
-            }
+                if (eventData.CreateDuplicateButton)
+                {
+                    var button = ui.ButtonRef(OfficialAssets.Graphics.Icons.Inspector.Duplicate, RadiantUI_Constants.Sub.GREEN, eventData.Inspector.OnDuplicateComponentPressed, worker);
+                    ConfigSection.DuplicateOffset.DriveFromVariable(button.Slot._orderOffset);
 
-            if (eventData.CreateDestroyButton)
-            {
-                var button = ui.ButtonRef(OfficialAssets.Graphics.Icons.Inspector.Destroy, RadiantUI_Constants.Sub.RED, eventData.Inspector.OnRemoveComponentPressed, worker);
-                ConfigSection.DestroyOffset.DriveFromVariable(button.Slot._orderOffset);
+                    eventData.DuplicateButton = button;
+                }
 
-                eventData.DestroyButton = button;
+                if (eventData.CreateDestroyButton)
+                {
+                    var button = ui.ButtonRef(OfficialAssets.Graphics.Icons.Inspector.Destroy, RadiantUI_Constants.Sub.RED, eventData.Inspector.OnRemoveComponentPressed, worker);
+                    ConfigSection.DestroyOffset.DriveFromVariable(button.Slot._orderOffset);
+
+                    eventData.DestroyButton = button;
+                }
             }
         }
     }

--- a/MonkeyLoader.Resonite.Integration/UI/Inspectors/DefaultInspectorHeaderHandler.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Inspectors/DefaultInspectorHeaderHandler.cs
@@ -32,7 +32,6 @@ namespace MonkeyLoader.Resonite.UI.Inspectors
                 eventData.WorkerNameButton = button;
             }
 
-            ui.PushStyle();
             ui.Style.FlexibleWidth = 0;
             ui.Style.MinWidth = 40;
 
@@ -59,8 +58,6 @@ namespace MonkeyLoader.Resonite.UI.Inspectors
 
                 eventData.DestroyButton = button;
             }
-
-            ui.PopStyle();
         }
     }
 }


### PR DESCRIPTION
Fixes UI style handling not matching vanilla, and also makes a design change by removing some calls to NestInto, therefore giving more control to event handlers, but also means they need to remember to properly nest out if they do any nesting themselves

Fixes https://github.com/EIA485/NeosInspectorDelegateCaller/issues/4