### PR TITLE
Check for `--hookfxr-disable` in Linux bootstrap script

### DIFF
--- a/MonkeyLoaderWrapper.Linux/run_monkeyloader.sh
+++ b/MonkeyLoaderWrapper.Linux/run_monkeyloader.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env sh
 
-sed -i '0,/dotnet Renderite.Host.dll "$@"/s//dotnet MonkeyLoaderWrapper.Linux.dll "$@"/' ./LinuxBootstrap.sh
+sed -i '/^# ~ Launch Resonite! :) ~$/c\
+if [[ "$*" != *"--hookfxr-disable"* ]]; then\
+    dotnet MonkeyLoaderWrapper.Linux.dll "$@"\
+    exit 0\
+fi' ./testing.sh
 "$@"

--- a/MonkeyLoaderWrapper.Linux/run_monkeyloader.sh
+++ b/MonkeyLoaderWrapper.Linux/run_monkeyloader.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-sed -i '/^# ~ Launch Resonite! :) ~$/c\
+sed -i '/^	# ~ Launch Resonite! :) ~$/c\
 if [[ "$*" != *"--hookfxr-disable"* ]]; then\
     dotnet MonkeyLoaderWrapper.Linux.dll "$@"\
     exit 0\

--- a/MonkeyLoaderWrapper.Linux/run_monkeyloader.sh
+++ b/MonkeyLoaderWrapper.Linux/run_monkeyloader.sh
@@ -4,5 +4,5 @@ sed -i '/^# ~ Launch Resonite! :) ~$/c\
 if [[ "$*" != *"--hookfxr-disable"* ]]; then\
     dotnet MonkeyLoaderWrapper.Linux.dll "$@"\
     exit 0\
-fi' ./testing.sh
+fi' ./LinuxBootstrap.sh
 "$@"


### PR DESCRIPTION
Allows for disabling mods with `--hookfxr-disable` on Linux

someone test this please ty

if the arg is not present it will execute the default `dotnet Renderite.Host.dll "$@"` (unless the user has modified the bootstrap script to do something else)

closes #154 