### PR TITLE
Change shebang to bash in LinuxBootstrap.sh

### DIFF
--- a/MonkeyLoaderWrapper.Linux/run_monkeyloader.sh
+++ b/MonkeyLoaderWrapper.Linux/run_monkeyloader.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env sh
 
+# change shebang in LinuxBootstrap.sh to support bash syntax
+sed -i '1s|/usr/bin/env sh|/usr/bin/env bash|' ./LinuxBootstrap.sh
+
 sed -i '/^	# ~ Launch Resonite! :) ~$/c\
 if [[ "$*" != *"--hookfxr-disable"* ]]; then\
     dotnet MonkeyLoaderWrapper.Linux.dll "$@"\


### PR DESCRIPTION
#155 broke the loader and causes an error in steam log `console-linux.txt`.
``` [...] /Steam/steamapps/common/Resonite/LinuxBootstrap.sh: 96: [[: not found```

Updates shebang in LinuxBootstrap.sh to use bash syntax and resolves #159
