### PR TITLE
Fix the startup crash that appeared with Resonite Beta v2026.4.23.62

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,14 @@ jobs:
     - name: Move NuGet Packages
       run: mv (Get-ChildItem -Recurse ./ -Include *.nupkg) ./
     
+    # Mark packages without version number in the name
+    - name: Mark unversioned NuGet Packages
+      run: Get-ChildItem -Include *.nupkg -Path ./* | Rename-Item -NewName { $_.Name -Replace '.*\D+\.nupkg','delete.nupkg' }
+
+    # Remove duplicate packages
+    - name: Delete marked Packages
+      run: Get-ChildItem -Include *delete.nupkg -Path ./* | Remove-Item
+      
     # Removes the version number from the package name
     - name: Rename NuGet Packages
       run: Get-ChildItem -Include *.nupkg -Path ./* | Rename-Item -NewName { $_.Name -Replace '\.\d+\.\d+\.\d+.*$','.nupkg' }

--- a/MonkeyLoader.Resonite.Data/MonkeyLoader.Resonite.Data.csproj
+++ b/MonkeyLoader.Resonite.Data/MonkeyLoader.Resonite.Data.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="FrooxEngine" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Remove="Publiciser.cs" />
     <Compile Remove="PubliciserSettings.cs" />
     <None Include="Publiciser.cs" />
@@ -14,5 +18,4 @@
   <ItemGroup>
     <PackageReference Include="MonkeyLoader" Version="0.29.0" />
   </ItemGroup>
-
 </Project>

--- a/MonkeyLoader.Resonite.Data/MonkeyLoader.Resonite.Data.csproj
+++ b/MonkeyLoader.Resonite.Data/MonkeyLoader.Resonite.Data.csproj
@@ -9,10 +9,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="NativeLibraryResolverRemover.cs" />
     <Compile Remove="Publiciser.cs" />
     <Compile Remove="PubliciserSettings.cs" />
     <None Include="Publiciser.cs" />
     <None Include="PubliciserSettings.cs" />
+    <None Include="NativeLibraryResolverRemover.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonkeyLoader.Resonite.Data/NativeLibraryResolverRemover.cs
+++ b/MonkeyLoader.Resonite.Data/NativeLibraryResolverRemover.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace MonkeyLoader.Resonite
 {
-    internal sealed class SharpFontNativeLoadFix : EarlyMonkey<SharpFontNativeLoadFix>
+    internal sealed class NativeLibraryResolverRemover : EarlyMonkey<NativeLibraryResolverRemover>
     {
         protected override IEnumerable<PrePatchTarget> GetPrePatchTargets()
         {

--- a/MonkeyLoader.Resonite.Data/SharpFontNativeLoadFix.cs
+++ b/MonkeyLoader.Resonite.Data/SharpFontNativeLoadFix.cs
@@ -1,0 +1,30 @@
+﻿using MonkeyLoader.Patching;
+using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MonkeyLoader.Resonite
+{
+    internal sealed class SharpFontNativeLoadFix : EarlyMonkey<SharpFontNativeLoadFix>
+    {
+        protected override IEnumerable<PrePatchTarget> GetPrePatchTargets()
+        {
+            yield return new PrePatchTarget(new("SharpFont"), "SharpFont.FT");
+            yield return new PrePatchTarget(new("SoundFlow"), "SoundFlow.Backends.MiniAudio.Native");
+        }
+
+        protected override bool Patch(PatchJob patchJob)
+        {
+            var type = patchJob.Types.First();
+            var staticConstructor = type.GetStaticConstructor();
+
+            var processor = staticConstructor.Body.GetILProcessor();
+            processor.Clear();
+            processor.Append(Instruction.Create(OpCodes.Ret));
+
+            patchJob.Changes = true;
+            return true;
+        }
+    }
+}

--- a/MonkeyLoader.Resonite.Data/TestPrePatcher.cs
+++ b/MonkeyLoader.Resonite.Data/TestPrePatcher.cs
@@ -3,18 +3,15 @@ using MonkeyLoader.Resonite.Features.FrooxEngine;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
 using MonoMod.Utils;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MonkeyLoader.Resonite
 {
-    // .NET Core enforces access checks, so this needs to be public for HelloMethod() to be callable from FrooxEngine
-    public sealed class TestPrePatcher : EarlyMonkey<TestPrePatcher>
+    // .NET Core enforces access checks, so this requires FrooxEngine to be included as InternalsVisibleTo to be callable from it
+    internal sealed class TestPrePatcher : EarlyMonkey<TestPrePatcher>
     {
-        public override string Name { get; } = "Test";
+        public override string Name => "Test";
 
         public static void HelloMethod()
             => Logger.Info(() => $"Hello from pre-patched-in FrooxEngine.Engine static constructor!");

--- a/MonkeyLoaderWrapper/Program.cs
+++ b/MonkeyLoaderWrapper/Program.cs
@@ -71,6 +71,17 @@ internal class Program
         }
     }
 
+    private static IEnumerable<string> RuntimeIdentifiers
+    {
+        get
+        {
+            yield return RuntimeInformation.RuntimeIdentifier;
+
+            if (RuntimeInformation.RuntimeIdentifier.IndexOf('-') is int index and > 0)
+                yield return RuntimeInformation.RuntimeIdentifier[..index];
+        }
+    }
+
     private static async Task Main(string[] args)
     {
         var loadContext = new MonkeyLoaderAssemblyLoadContext(_monkeyLoaderPath.DirectoryName!, (assemblyName) =>
@@ -117,12 +128,7 @@ internal class Program
 
         // TODO: Should not be necessary anymore with the hookfxr changes. Either way, should be done by the load context
         foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            if (assembly.GetName().Name is "SoundFlow" or "SharpFont")
-                continue;
-
             NativeLibrary.SetDllImportResolver(assembly, ResolveNativeLibrary);
-        }
 
         var mainResult = resoniteAssembly.EntryPoint!.Invoke(null, [args]);
 
@@ -132,11 +138,7 @@ internal class Program
 
     private static IntPtr ResolveNativeLibrary(string nativeLibraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
-        if (nativeLibraryName == "rnnoise")
-            return IntPtr.Zero;
-
-        var runtimesPath = Path.Combine(_resonitePath.DirectoryName!, "runtimes",
-            RuntimeInformation.RuntimeIdentifier, "native");
+        var runtimesBasePath = Path.Combine(_resonitePath.DirectoryName!, "runtimes");
 
         IEnumerable<string> libraryNames = [nativeLibraryName];
 
@@ -145,14 +147,19 @@ internal class Program
 
         foreach (var libraryName in libraryNames)
         {
-            foreach (var libraryPrefix in LibraryPrefixes)
+            foreach (var runtimeIdentifier in RuntimeIdentifiers)
             {
-                foreach (var libraryExtension in LibraryExtensions)
-                {
-                    var libraryPath = Path.Combine(runtimesPath, $"{libraryPrefix}{libraryName}{libraryExtension}");
+                var runtimesPath = Path.Combine(runtimesBasePath, runtimeIdentifier, "native");
 
-                    if (File.Exists(libraryPath))
-                        return NativeLibrary.Load(libraryPath);
+                foreach (var libraryPrefix in LibraryPrefixes)
+                {
+                    foreach (var libraryExtension in LibraryExtensions)
+                    {
+                        var libraryPath = Path.Combine(runtimesPath, $"{libraryPrefix}{libraryName}{libraryExtension}");
+
+                        if (File.Exists(libraryPath))
+                            return NativeLibrary.Load(libraryPath);
+                    }
                 }
             }
         }

--- a/MonkeyLoaderWrapper/Program.cs
+++ b/MonkeyLoaderWrapper/Program.cs
@@ -3,43 +3,13 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 
-internal class MonkeyLoaderAssemblyLoadContext(
-    string monkeyLoaderPath,
-    MonkeyLoaderAssemblyLoadContext.AssemblyResolveEventHandler handler)
+internal sealed class MonkeyLoaderAssemblyLoadContext(
+        string monkeyLoaderPath,
+        MonkeyLoaderAssemblyLoadContext.AssemblyResolveEventHandler handler)
     : AssemblyLoadContext("MonkeyLoader")
 {
-    private readonly AssemblyResolveEventHandler? _assemblyResolveEventHandler = handler;
-
-    protected override Assembly? Load(AssemblyName assemblyName)
-    {
-        Debug.WriteLine($"MonkeyLoaderAssemblyLoadContext: Resolving {assemblyName.FullName}");
-
-        if (_assemblyResolveEventHandler != null)
-        {
-            var resolvedAssembly = _assemblyResolveEventHandler(assemblyName);
-            if (resolvedAssembly != null)
-            {
-                Debug.WriteLine($"=> Resolved assembly: {resolvedAssembly.FullName}");
-                return resolvedAssembly;
-            }
-        }
-
-        var name = assemblyName.Name;
-        var mlPath = Path.Combine(monkeyLoaderPath, $"{name}.dll");
-        return File.Exists(mlPath) ? LoadFromAssemblyPath(mlPath) : null;
-    }
-
-    public delegate Assembly? AssemblyResolveEventHandler(AssemblyName assemblyName);
-}
-
-internal class Program
-{
-    private static readonly FileInfo _monkeyLoaderPath = new(Path.Combine("MonkeyLoader", "MonkeyLoader.dll"));
-
     private static readonly FileInfo _resonitePath = new("Renderite.Host.dll");
-
-    private static object? _monkeyLoaderInstance = null;
-    private static MethodInfo? _monkeyLoaderResolveAssemblyMethod = null;
+    private readonly AssemblyResolveEventHandler? _assemblyResolveEventHandler = handler;
 
     private static IEnumerable<string> LibraryExtensions
     {
@@ -81,6 +51,69 @@ internal class Program
                 yield return RuntimeInformation.RuntimeIdentifier[..index];
         }
     }
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        Debug.WriteLine($"MonkeyLoaderAssemblyLoadContext: Resolving {assemblyName.FullName}");
+
+        if (_assemblyResolveEventHandler != null)
+        {
+            var resolvedAssembly = _assemblyResolveEventHandler(assemblyName);
+            if (resolvedAssembly != null)
+            {
+                Debug.WriteLine($"=> Resolved assembly: {resolvedAssembly.FullName}");
+                return resolvedAssembly;
+            }
+        }
+
+        var name = assemblyName.Name;
+        var mlPath = Path.Combine(monkeyLoaderPath, $"{name}.dll");
+        return File.Exists(mlPath) ? LoadFromAssemblyPath(mlPath) : null;
+    }
+
+    // TODO: Should not be necessary anymore with the hookfxr changes. Either way, should be done by the load context
+    protected override nint LoadUnmanagedDll(string unmanagedDllName)
+    {
+        var runtimesBasePath = Path.Combine(_resonitePath.DirectoryName!, "runtimes");
+
+        IEnumerable<string> libraryNames = [unmanagedDllName];
+
+        if (unmanagedDllName.EndsWith("64") || unmanagedDllName.EndsWith("32"))
+            libraryNames = libraryNames.Concat([unmanagedDllName[..^2]]);
+
+        foreach (var libraryName in libraryNames)
+        {
+            foreach (var runtimeIdentifier in RuntimeIdentifiers)
+            {
+                var runtimesPath = Path.Combine(runtimesBasePath, runtimeIdentifier, "native");
+
+                foreach (var libraryPrefix in LibraryPrefixes)
+                {
+                    foreach (var libraryExtension in LibraryExtensions)
+                    {
+                        var libraryPath = Path.Combine(runtimesPath, $"{libraryPrefix}{libraryName}{libraryExtension}");
+
+                        if (File.Exists(libraryPath))
+                            return NativeLibrary.Load(libraryPath);
+                    }
+                }
+            }
+        }
+
+        return IntPtr.Zero;
+    }
+
+    public delegate Assembly? AssemblyResolveEventHandler(AssemblyName assemblyName);
+}
+
+internal class Program
+{
+    private static readonly FileInfo _monkeyLoaderPath = new(Path.Combine("MonkeyLoader", "MonkeyLoader.dll"));
+
+    private static readonly FileInfo _resonitePath = new("Renderite.Host.dll");
+
+    private static object? _monkeyLoaderInstance = null;
+    private static MethodInfo? _monkeyLoaderResolveAssemblyMethod = null;
 
     private static async Task Main(string[] args)
     {
@@ -126,44 +159,9 @@ internal class Program
 
         var resoniteAssembly = loadContext.LoadFromAssemblyPath(_resonitePath.FullName);
 
-        // TODO: Should not be necessary anymore with the hookfxr changes. Either way, should be done by the load context
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-            NativeLibrary.SetDllImportResolver(assembly, ResolveNativeLibrary);
-
         var mainResult = resoniteAssembly.EntryPoint!.Invoke(null, [args]);
 
         if (mainResult is Task task)
             await task;
-    }
-
-    private static IntPtr ResolveNativeLibrary(string nativeLibraryName, Assembly assembly, DllImportSearchPath? searchPath)
-    {
-        var runtimesBasePath = Path.Combine(_resonitePath.DirectoryName!, "runtimes");
-
-        IEnumerable<string> libraryNames = [nativeLibraryName];
-
-        if (nativeLibraryName.EndsWith("64") || nativeLibraryName.EndsWith("32"))
-            libraryNames = libraryNames.Concat([nativeLibraryName[..^2]]);
-
-        foreach (var libraryName in libraryNames)
-        {
-            foreach (var runtimeIdentifier in RuntimeIdentifiers)
-            {
-                var runtimesPath = Path.Combine(runtimesBasePath, runtimeIdentifier, "native");
-
-                foreach (var libraryPrefix in LibraryPrefixes)
-                {
-                    foreach (var libraryExtension in LibraryExtensions)
-                    {
-                        var libraryPath = Path.Combine(runtimesPath, $"{libraryPrefix}{libraryName}{libraryExtension}");
-
-                        if (File.Exists(libraryPath))
-                            return NativeLibrary.Load(libraryPath);
-                    }
-                }
-            }
-        }
-
-        return IntPtr.Zero;
     }
 }

--- a/MonkeyLoaderWrapper/Program.cs
+++ b/MonkeyLoaderWrapper/Program.cs
@@ -4,53 +4,13 @@ using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 
 internal sealed class MonkeyLoaderAssemblyLoadContext(
+        string resonitePath,
         string monkeyLoaderPath,
         MonkeyLoaderAssemblyLoadContext.AssemblyResolveEventHandler handler)
     : AssemblyLoadContext("MonkeyLoader")
 {
-    private static readonly FileInfo _resonitePath = new("Renderite.Host.dll");
     private readonly AssemblyResolveEventHandler? _assemblyResolveEventHandler = handler;
-
-    private static IEnumerable<string> LibraryExtensions
-    {
-        get
-        {
-            yield return ".dll";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                yield break;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                yield return ".so";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                yield return ".dylib";
-        }
-    }
-
-    private static IEnumerable<string> LibraryPrefixes
-    {
-        get
-        {
-            yield return string.Empty;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                yield break;
-
-            yield return "lib";
-        }
-    }
-
-    private static IEnumerable<string> RuntimeIdentifiers
-    {
-        get
-        {
-            yield return RuntimeInformation.RuntimeIdentifier;
-
-            if (RuntimeInformation.RuntimeIdentifier.IndexOf('-') is int index and > 0)
-                yield return RuntimeInformation.RuntimeIdentifier[..index];
-        }
-    }
+    private readonly AssemblyDependencyResolver _dependencyResolver = new(resonitePath);
 
     protected override Assembly? Load(AssemblyName assemblyName)
     {
@@ -68,39 +28,24 @@ internal sealed class MonkeyLoaderAssemblyLoadContext(
 
         var name = assemblyName.Name;
         var mlPath = Path.Combine(monkeyLoaderPath, $"{name}.dll");
-        return File.Exists(mlPath) ? LoadFromAssemblyPath(mlPath) : null;
+        if (File.Exists(mlPath))
+            return LoadFromAssemblyPath(mlPath);
+
+        if (_dependencyResolver.ResolveAssemblyToPath(assemblyName) is null)
+            return null;
+
+        return LoadFromAssemblyPath(mlPath);
     }
 
-    // TODO: Should not be necessary anymore with the hookfxr changes. Either way, should be done by the load context
+    // TODO: Should not be necessary anymore with the hookfxr changes.
     protected override nint LoadUnmanagedDll(string unmanagedDllName)
     {
-        var runtimesBasePath = Path.Combine(_resonitePath.DirectoryName!, "runtimes");
+        Debug.WriteLine($"MonkeyLoaderAssemblyLoadContext: Resolving unmanaged {unmanagedDllName}");
 
-        IEnumerable<string> libraryNames = [unmanagedDllName];
+        if (_dependencyResolver.ResolveUnmanagedDllToPath(unmanagedDllName) is not string resolvedPath)
+            return nint.Zero;
 
-        if (unmanagedDllName.EndsWith("64") || unmanagedDllName.EndsWith("32"))
-            libraryNames = libraryNames.Concat([unmanagedDllName[..^2]]);
-
-        foreach (var libraryName in libraryNames)
-        {
-            foreach (var runtimeIdentifier in RuntimeIdentifiers)
-            {
-                var runtimesPath = Path.Combine(runtimesBasePath, runtimeIdentifier, "native");
-
-                foreach (var libraryPrefix in LibraryPrefixes)
-                {
-                    foreach (var libraryExtension in LibraryExtensions)
-                    {
-                        var libraryPath = Path.Combine(runtimesPath, $"{libraryPrefix}{libraryName}{libraryExtension}");
-
-                        if (File.Exists(libraryPath))
-                            return NativeLibrary.Load(libraryPath);
-                    }
-                }
-            }
-        }
-
-        return IntPtr.Zero;
+        return LoadUnmanagedDllFromPath(resolvedPath);
     }
 
     public delegate Assembly? AssemblyResolveEventHandler(AssemblyName assemblyName);
@@ -117,7 +62,7 @@ internal class Program
 
     private static async Task Main(string[] args)
     {
-        var loadContext = new MonkeyLoaderAssemblyLoadContext(_monkeyLoaderPath.DirectoryName!, (assemblyName) =>
+        var loadContext = new MonkeyLoaderAssemblyLoadContext(_resonitePath.FullName!, _monkeyLoaderPath.DirectoryName!, (assemblyName) =>
         {
             if (_monkeyLoaderInstance == null || _monkeyLoaderResolveAssemblyMethod == null)
                 return null;


### PR DESCRIPTION
Add pre-patcher that removes the NativeLibraryResolver from SharpFont and SoundFlow; remove rnnoise exclusion for resolving

This fixes the startup crash that appeared with Resonite Beta v2026.4.23.62