### PR TITLE
Improve ReferenceProxySource resolver; add complementary SlotRecord resolver; add AsModLocaleKey extension

### DIFF
--- a/MonkeyLoader.Resonite.Core/FieldExtensions.cs
+++ b/MonkeyLoader.Resonite.Core/FieldExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using FrooxEngine;
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace MonkeyLoader.Resonite
 {
@@ -14,10 +11,16 @@ namespace MonkeyLoader.Resonite
     public static class FieldExtensions
     {
         /// <summary>
-        /// Creates a label describing the <paramref name="target"/> reference as a <see cref="RefEditor"/> would.
+        /// Creates a label describing the <paramref name="target"/> reference almost as a <see cref="RefEditor"/> would.
         /// </summary>
+        /// <remarks>
+        /// For <see cref="Slot"/>s, their <see cref="Component"/>s, and the fields of those the behavior is the same.<br/>
+        /// For <see cref="User"/>s, this format is instead:
+        /// <c>$"&lt;noparse&gt;{<see cref="User">targetUser</see>.<see cref="User.UserName">UserName</see>}
+        /// ({<paramref name="target"/>.<see cref="IWorldElement.ReferenceID">ReferenceID</see>})&lt;/noparse&gt;"</c>
+        /// </remarks>
         /// <param name="target">The reference to label.</param>
-        /// <returns>A label for the <paramref name="target"/> reference if it is not <c>null</c>; otherwise, <c>&lt;i&gt;null&lt;/i&gt;</c>.</returns>
+        /// <returns>A label for the <paramref name="target"/> reference if it is not <c>null</c>; otherwise, <c>"&lt;i&gt;null&lt;/i&gt;"</c>.</returns>
         public static string GetReferenceLabel(this IWorldElement? target)
         {
             if (target is null)
@@ -25,6 +28,9 @@ namespace MonkeyLoader.Resonite
 
             if (target is Slot targetSlot)
                 return $"{targetSlot.Name} ({target.ReferenceID})";
+
+            if (target is User targetUser)
+                return $"<noparse>{targetUser.UserName} ({target.ReferenceID})</noparse>";
 
             var component = target.FindNearestParent<Component>();
             var slot = component?.Slot ?? target.FindNearestParent<Slot>();

--- a/MonkeyLoader.Resonite.Integration/DataFeeds/Settings/ConfigToSettingsExtensions.cs
+++ b/MonkeyLoader.Resonite.Integration/DataFeeds/Settings/ConfigToSettingsExtensions.cs
@@ -409,7 +409,7 @@ namespace MonkeyLoader.Resonite.DataFeeds.Settings
             var flagsEnumGroup = new DataFeedGroup();
             flagsEnumGroup.InitBase(configKey.FullId + ".Flags", path, groupKeys, Mod.GetLocaleString("EnumFlags.Name", ("KeyId", configKey.Id)));
             flagsEnumGroup.InitSorting(-configKey.Priority);
-            flagsEnumGroup.InitDescription(configKey.GetLocaleKey("Description").AsLocaleKey());
+            flagsEnumGroup.InitDescription(configKey.GetLocaleKey("Description").AsModLocaleKey(Mod));
             yield return flagsEnumGroup;
 
             var flagsGrouping = groupKeys.Concat([configKey.FullId + ".Flags"]).ToArray();

--- a/MonkeyLoader.Resonite.Integration/Locale/General/de.json
+++ b/MonkeyLoader.Resonite.Integration/Locale/General/de.json
@@ -19,6 +19,11 @@
     "MonkeyLoader.GamePacks.Resonite.Tooltip.OpenHyperlink.WithLabel": "{label}<size=50%><br/><br/></size><b>Grund:</b> <i>{reason}</i><br/><b>URL:</b> <i>{url}</i>",
 
     "MonkeyLoader.GamePacks.Resonite.Tooltip.WikiHyperlink.Component": "Öffnet den Resonite Wiki Artikel über diese Komponente.",
-    "MonkeyLoader.GamePacks.Resonite.Tooltip.WikiHyperlink.ProtoFlux": "Öffnet den Resonite Wiki Artikel über diese ProtoFlux Node."
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.WikiHyperlink.ProtoFlux": "Öffnet den Resonite Wiki Artikel über diese ProtoFlux Node.",
+
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.ReferenceProxySource": "Greif eine Referenz zu {target}.",
+
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.SlotRecord.Generic": "Greif eine Referenz zu diesem Slot, oder ziehe andere Slots hierher, um sie unter diesem einzuhängen, wobei ihre globale Position erhalten bleibt.",
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.SlotRecord.Inspector": "Öffnet diesen Slot im Inspektor, greif eine Referenz zu ihm, oder ziehe andere Slots hierher, um sie unter diesem einzuhängen, wobei ihre globale Position erhalten bleibt."
   }
 }

--- a/MonkeyLoader.Resonite.Integration/Locale/General/de.json
+++ b/MonkeyLoader.Resonite.Integration/Locale/General/de.json
@@ -23,7 +23,7 @@
 
     "MonkeyLoader.GamePacks.Resonite.Tooltip.ReferenceProxySource": "Greif eine Referenz zu {target}.",
 
-    "MonkeyLoader.GamePacks.Resonite.Tooltip.SlotRecord.Generic": "Greif eine Referenz zu diesem Slot, oder ziehe andere Slots hierher, um sie unter diesem einzuhängen, wobei ihre globale Position erhalten bleibt.",
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.SlotRecord.Generic": "Greif eine Referenz zum Slot {target}, oder ziehe andere Slots hierher, um sie unter diesem einzuhängen, wobei ihre globale Position erhalten bleibt.",
     "MonkeyLoader.GamePacks.Resonite.Tooltip.SlotRecord.Inspector": "Öffnet diesen Slot im Inspektor, greif eine Referenz zu ihm, oder ziehe andere Slots hierher, um sie unter diesem einzuhängen, wobei ihre globale Position erhalten bleibt."
   }
 }

--- a/MonkeyLoader.Resonite.Integration/Locale/General/en.json
+++ b/MonkeyLoader.Resonite.Integration/Locale/General/en.json
@@ -23,7 +23,7 @@
 
     "MonkeyLoader.GamePacks.Resonite.Tooltip.ReferenceProxySource": "Grab a reference to {target}.",
 
-    "MonkeyLoader.GamePacks.Resonite.Tooltip.SlotRecord.Generic": "Grab a reference to this slot, or drag'n'drop other slots onto here to parent them to it while preserving their global position.",
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.SlotRecord.Generic": "Grab a reference to the slot {target}, or drag'n'drop other slots onto here to parent them to it while preserving their global position.",
     "MonkeyLoader.GamePacks.Resonite.Tooltip.SlotRecord.Inspector": "Opens this slot in the inspector, grab a reference to it, or drag'n'drop other slots onto here to parent them to this slot while preserving their global position."
   }
 }

--- a/MonkeyLoader.Resonite.Integration/Locale/General/en.json
+++ b/MonkeyLoader.Resonite.Integration/Locale/General/en.json
@@ -19,6 +19,11 @@
     "MonkeyLoader.GamePacks.Resonite.Tooltip.OpenHyperlink.WithLabel": "{label}<size=50%><br/><br/></size><b>Reason:</b> <i>{reason}</i><br/><b>URL:</b> <i>{url}</i>",
 
     "MonkeyLoader.GamePacks.Resonite.Tooltip.WikiHyperlink.Component": "Opens the Resonite Wiki article about this Component.",
-    "MonkeyLoader.GamePacks.Resonite.Tooltip.WikiHyperlink.ProtoFlux": "Opens the Resonite Wiki article about this ProtoFlux node."
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.WikiHyperlink.ProtoFlux": "Opens the Resonite Wiki article about this ProtoFlux node.",
+
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.ReferenceProxySource": "Grab a reference to {target}.",
+
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.SlotRecord.Generic": "Grab a reference to this slot, or drag'n'drop other slots onto here to parent them to it while preserving their global position.",
+    "MonkeyLoader.GamePacks.Resonite.Tooltip.SlotRecord.Inspector": "Opens this slot in the inspector, grab a reference to it, or drag'n'drop other slots onto here to parent them to this slot while preserving their global position."
   }
 }

--- a/MonkeyLoader.Resonite.Integration/LocaleExtensions.cs
+++ b/MonkeyLoader.Resonite.Integration/LocaleExtensions.cs
@@ -77,14 +77,20 @@ namespace MonkeyLoader.Resonite
             => key.AsLocaleKey(format, arguments.AddModIndicator(identifiable));
 
         /// <param name="continuous">Whether to assign the locale message once or continuously.</param>
-        /// <param name="arguments">The arguments used to format the locale message.</param>
+        /// <param name="arguments">
+        /// The arguments used to format the locale message.<br/>
+        /// Note that <see cref="ModLocaleStringIndicatorArgumentName">mod indicator</see> will be added to this.
+        /// </param>
         /// <inheritdoc cref="AsModLocaleKey(string, IIdentifiable, string, object)"/>
         public static LocaleString AsModLocaleKey(this string key, IIdentifiable identifiable, bool continuous, Dictionary<string, object>? arguments = null)
             => key.AsLocaleKey(continuous, arguments.AddModIndicator(identifiable));
 
         /// <param name="format">An additional format string to insert the locale message into.</param>
         /// <param name="continuous">Whether to assign the locale message once or continuously.</param>
-        /// <param name="arguments">The arguments used to format the locale message.</param>
+        /// <param name="arguments">
+        /// The arguments used to format the locale message.<br/>
+        /// Note that <see cref="ModLocaleStringIndicatorArgumentName">mod indicator</see> will be added to this.
+        /// </param>
         /// <inheritdoc cref="AsModLocaleKey(string, IIdentifiable, string, object)"/>
         public static LocaleString AsModLocaleKey(this string key, IIdentifiable identifiable, string? format = null, bool continuous = true, Dictionary<string, object>? arguments = null)
             => key.AsLocaleKey(format!, continuous, arguments.AddModIndicator(identifiable));
@@ -238,14 +244,20 @@ namespace MonkeyLoader.Resonite
             => identifiable.GetLocaleKey(key).AsModLocaleKey(identifiable, format, arguments);
 
         /// <param name="continuous">Whether to assign the locale message once or continuously.</param>
-        /// <param name="arguments">The arguments used to format the locale message.</param>
+        /// <param name="arguments">
+        /// The arguments used to format the locale message.<br/>
+        /// Note that <see cref="ModLocaleStringIndicatorArgumentName">mod indicator</see> will be added to this.
+        /// </param>
         /// <inheritdoc cref="GetLocaleString(IIdentifiable, string, string, object)"/>
         public static LocaleString GetLocaleString(this IIdentifiable identifiable, string key, bool continuous, Dictionary<string, object>? arguments = null)
             => identifiable.GetLocaleKey(key).AsModLocaleKey(identifiable, continuous, arguments);
 
         /// <param name="format">An additional format string to insert the locale message into.</param>
         /// <param name="continuous">Whether to assign the locale message once or continuously.</param>
-        /// <param name="arguments">The arguments used to format the locale message.</param>
+        /// <param name="arguments">
+        /// The arguments used to format the locale message.<br/>
+        /// Note that <see cref="ModLocaleStringIndicatorArgumentName">mod indicator</see> will be added to this.
+        /// </param>
         /// <inheritdoc cref="GetLocaleString(IIdentifiable, string, string, object)"/>
         public static LocaleString GetLocaleString(this IIdentifiable identifiable, string key, string? format = null, bool continuous = true, Dictionary<string, object>? arguments = null)
             => identifiable.GetLocaleKey(key).AsModLocaleKey(identifiable, format!, continuous, arguments);

--- a/MonkeyLoader.Resonite.Integration/LocaleExtensions.cs
+++ b/MonkeyLoader.Resonite.Integration/LocaleExtensions.cs
@@ -1,14 +1,12 @@
 ﻿using Elements.Core;
 using FrooxEngine;
+using MonkeyLoader.Configuration;
 using MonkeyLoader.Meta;
 using MonkeyLoader.Resonite.Locale;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 using LocaleResourceData = Elements.Assets.LocaleResource;
+
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 
 namespace MonkeyLoader.Resonite
 {
@@ -40,6 +38,56 @@ namespace MonkeyLoader.Resonite
         /// Gets the latest loaded <see cref="Elements.Assets.LocaleResource"/> data for the fallback locale.
         /// </summary>
         public static LocaleResourceData FallbackLocale { get; private set; } = new();
+
+        /// <summary>
+        /// Uses this string as the <paramref name="key"/> to create a <see cref="LocaleString"/> using the other arguments,
+        /// which <see cref="IsModLocaleString">is indicated to be from a mod</see>.
+        /// </summary>
+        /// <param name="identifiable"><para>
+        /// The <see cref="IIdentifiable"/> used to indicate that the resulting
+        /// <see cref="LocaleString"/> <see cref="IsModLocaleString">is from a mod</see>.
+        /// </para><para>
+        /// Typically, this should be the <see cref="Mod"/> that this method is being called by,
+        /// but its children like <see cref="IMonkey">Monkeys</see>, or any config elements
+        /// (<see cref="Config"/>/<see cref="ConfigSection"/>/<see cref="DefiningConfigKey{T}"/>) work too.
+        /// </para></param>
+        /// <param name="key">The locale key to use.</param>
+        /// <param name="argName">The name of the single argument used to format the locale message.</param>
+        /// <param name="argField">The value of the single argument used to format the locale message.</param>
+        /// <returns>The <see cref="IsModLocaleString">Mod</see>-<see cref="LocaleString"/> created from the key with the arguments.</returns>
+        public static LocaleString AsModLocaleKey(this string key, IIdentifiable identifiable, string argName, object argField)
+            => key.AsLocaleKey((argName, argField), (ModLocaleStringIndicatorArgumentName, identifiable.GetMod()));
+
+        /// <param name="format">An additional format string to insert the locale message into.</param>
+        /// <param name="argName">The name of the single argument used to format the locale message.</param>
+        /// <param name="argField">The value of the single argument used to format the locale message.</param>
+        /// <inheritdoc cref="AsModLocaleKey(string, IIdentifiable, string, object)"/>
+        public static LocaleString AsModLocaleKey(this string key, IIdentifiable identifiable, string format, string argName, object argField)
+            => key.AsLocaleKey(format, (argName, argField), (ModLocaleStringIndicatorArgumentName, identifiable.GetMod()));
+
+        /// <param name="arguments">The arguments used to format the locale message.</param>
+        /// <inheritdoc cref="AsModLocaleKey(string, IIdentifiable, string, object)"/>
+        public static LocaleString AsModLocaleKey(this string key, IIdentifiable identifiable, params (string, object)[] arguments)
+            => key.AsLocaleKey(arguments.AddModIndicator(identifiable));
+
+        /// <param name="format">An additional format string to insert the locale message into.</param>
+        /// <param name="arguments">The arguments used to format the locale message.</param>
+        /// <inheritdoc cref="AsModLocaleKey(string, IIdentifiable, string, object)"/>
+        public static LocaleString AsModLocaleKey(this string key, IIdentifiable identifiable, string format, params (string, object)[] arguments)
+            => key.AsLocaleKey(format, arguments.AddModIndicator(identifiable));
+
+        /// <param name="continuous">Whether to assign the locale message once or continuously.</param>
+        /// <param name="arguments">The arguments used to format the locale message.</param>
+        /// <inheritdoc cref="AsModLocaleKey(string, IIdentifiable, string, object)"/>
+        public static LocaleString AsModLocaleKey(this string key, IIdentifiable identifiable, bool continuous, Dictionary<string, object>? arguments = null)
+            => key.AsLocaleKey(continuous, arguments.AddModIndicator(identifiable));
+
+        /// <param name="format">An additional format string to insert the locale message into.</param>
+        /// <param name="continuous">Whether to assign the locale message once or continuously.</param>
+        /// <param name="arguments">The arguments used to format the locale message.</param>
+        /// <inheritdoc cref="AsModLocaleKey(string, IIdentifiable, string, object)"/>
+        public static LocaleString AsModLocaleKey(this string key, IIdentifiable identifiable, string? format = null, bool continuous = true, Dictionary<string, object>? arguments = null)
+            => key.AsLocaleKey(format!, continuous, arguments.AddModIndicator(identifiable));
 
         /// <summary>
         /// Exports the fallback <see cref="Elements.Assets.LocaleData">locale
@@ -154,76 +202,53 @@ namespace MonkeyLoader.Resonite
 
         /// <summary>
         /// Uses <c><paramref name="identifiable"/>.<see cref="GetLocaleKey">GetLocaleKey</see>(<paramref name="key"/>)</c>
-        /// as the key to create a <see cref="LocaleString"/> using the other arguments.
+        /// as the key to create a <see cref="LocaleString"/> using the other arguments,
+        /// which <see cref="IsModLocaleString">is indicated to be from a mod</see>.
         /// </summary>
-        /// <param name="identifiable">The <see cref="IIdentifiable"/> whose <see cref="IIdentifiable.FullId">FullId</see> to use as a prefix.</param>
-        /// <param name="key">The locale key to prefix.</param>
+        /// <param name="identifiable"><para>
+        /// The <see cref="IIdentifiable"/> whose <see cref="IIdentifiable.FullId">FullId</see> to use as a prefix for the <paramref name="key"/>.
+        /// </para><para>
+        /// Typically, this should be the <see cref="Mod"/> that this method is being called by,
+        /// but its children like <see cref="IMonkey">Monkeys</see>, or any config elements
+        /// (<see cref="Config"/>/<see cref="ConfigSection"/>/<see cref="DefiningConfigKey{T}"/>) work too.
+        /// </para></param>
+        /// <param name="key">The locale key fragment to prefix.</param>
         /// <param name="argName">The name of the single argument used to format the locale message.</param>
         /// <param name="argField">The value of the single argument used to format the locale message.</param>
         /// <returns>The <see cref="IsModLocaleString">Mod</see>-<see cref="LocaleString"/> created from the key with the arguments.</returns>
         public static LocaleString GetLocaleString(this IIdentifiable identifiable, string key, string argName, object argField)
-            => identifiable.GetLocaleKey(key).AsLocaleKey((argName, argField), (ModLocaleStringIndicatorArgumentName, identifiable.GetMod()));
+            => identifiable.GetLocaleKey(key).AsModLocaleKey(identifiable, argName, argField);
 
-        /// <summary>
-        /// Uses <c><paramref name="identifiable"/>.<see cref="GetLocaleKey">GetLocaleKey</see>(<paramref name="key"/>)</c>
-        /// as the key to create a <see cref="LocaleString"/> using the other arguments.
-        /// </summary>
-        /// <param name="identifiable">The <see cref="IIdentifiable"/> whose <see cref="IIdentifiable.FullId">FullId</see> to use as a prefix.</param>
-        /// <param name="key">The locale key to prefix.</param>
         /// <param name="format">An additional format string to insert the locale message into.</param>
         /// <param name="argName">The name of the single argument used to format the locale message.</param>
         /// <param name="argField">The value of the single argument used to format the locale message.</param>
-        /// <returns>The <see cref="IsModLocaleString">Mod</see>-<see cref="LocaleString"/> created from the key with the arguments.</returns>
+        /// <inheritdoc cref="GetLocaleString(IIdentifiable, string, string, object)"/>
         public static LocaleString GetLocaleString(this IIdentifiable identifiable, string key, string format, string argName, object argField)
-            => identifiable.GetLocaleKey(key).AsLocaleKey(format, (argName, argField), (ModLocaleStringIndicatorArgumentName, identifiable.GetMod()));
+            => identifiable.GetLocaleKey(key).AsModLocaleKey(identifiable, format, argName, argField);
 
-        /// <summary>
-        /// Uses <c><paramref name="identifiable"/>.<see cref="GetLocaleKey">GetLocaleKey</see>(<paramref name="key"/>)</c>
-        /// as the key to create a <see cref="LocaleString"/> using the other arguments.
-        /// </summary>
-        /// <param name="identifiable">The <see cref="IIdentifiable"/> whose <see cref="IIdentifiable.FullId">FullId</see> to use as a prefix.</param>
-        /// <param name="key">The locale key to prefix.</param>
         /// <param name="arguments">The arguments used to format the locale message.</param>
-        /// <returns>The <see cref="IsModLocaleString">Mod</see>-<see cref="LocaleString"/> created from the key with the arguments.</returns>
+        /// <inheritdoc cref="GetLocaleString(IIdentifiable, string, string, object)"/>
         public static LocaleString GetLocaleString(this IIdentifiable identifiable, string key, params (string, object)[] arguments)
-            => identifiable.GetLocaleKey(key).AsLocaleKey(arguments.AddModIndicator(identifiable));
+            => identifiable.GetLocaleKey(key).AsModLocaleKey(identifiable, arguments);
 
-        /// <summary>
-        /// Uses <c><paramref name="identifiable"/>.<see cref="GetLocaleKey">GetLocaleKey</see>(<paramref name="key"/>)</c>
-        /// as the key to create a <see cref="LocaleString"/> using the other arguments.
-        /// </summary>
-        /// <param name="identifiable">The <see cref="IIdentifiable"/> whose <see cref="IIdentifiable.FullId">FullId</see> to use as a prefix.</param>
-        /// <param name="key">The locale key to prefix.</param>
         /// <param name="format">An additional format string to insert the locale message into.</param>
         /// <param name="arguments">The arguments used to format the locale message.</param>
-        /// <returns>The <see cref="IsModLocaleString">Mod</see>-<see cref="LocaleString"/> created from the key with the arguments.</returns>
+        /// <inheritdoc cref="GetLocaleString(IIdentifiable, string, string, object)"/>
         public static LocaleString GetLocaleString(this IIdentifiable identifiable, string key, string format, params (string, object)[] arguments)
-            => identifiable.GetLocaleKey(key).AsLocaleKey(format, arguments.AddModIndicator(identifiable));
+            => identifiable.GetLocaleKey(key).AsModLocaleKey(identifiable, format, arguments);
 
-        /// <summary>
-        /// Uses <c><paramref name="identifiable"/>.<see cref="GetLocaleKey">GetLocaleKey</see>(<paramref name="key"/>)</c>
-        /// as the key to create a <see cref="LocaleString"/> using the other arguments.
-        /// </summary>
-        /// <param name="identifiable">The <see cref="IIdentifiable"/> whose <see cref="IIdentifiable.FullId">FullId</see> to use as a prefix.</param>
-        /// <param name="key">The locale key to prefix.</param>
         /// <param name="continuous">Whether to assign the locale message once or continuously.</param>
         /// <param name="arguments">The arguments used to format the locale message.</param>
-        /// <returns>The <see cref="IsModLocaleString">Mod</see>-<see cref="LocaleString"/> created from the key with the arguments.</returns>
+        /// <inheritdoc cref="GetLocaleString(IIdentifiable, string, string, object)"/>
         public static LocaleString GetLocaleString(this IIdentifiable identifiable, string key, bool continuous, Dictionary<string, object>? arguments = null)
-            => identifiable.GetLocaleKey(key).AsLocaleKey(continuous, arguments.AddModIndicator(identifiable));
+            => identifiable.GetLocaleKey(key).AsModLocaleKey(identifiable, continuous, arguments);
 
-        /// <summary>
-        /// Uses <c><paramref name="identifiable"/>.<see cref="GetLocaleKey">GetLocaleKey</see>(<paramref name="key"/>)</c>
-        /// as the key to create a <see cref="LocaleString"/> using the other arguments.
-        /// </summary>
-        /// <param name="identifiable">The <see cref="IIdentifiable"/> whose <see cref="IIdentifiable.FullId">FullId</see> to use as a prefix.</param>
-        /// <param name="key">The locale key to prefix.</param>
         /// <param name="format">An additional format string to insert the locale message into.</param>
         /// <param name="continuous">Whether to assign the locale message once or continuously.</param>
         /// <param name="arguments">The arguments used to format the locale message.</param>
-        /// <returns>The <see cref="IsModLocaleString">Mod</see>-<see cref="LocaleString"/> created from the key with the arguments.</returns>
+        /// <inheritdoc cref="GetLocaleString(IIdentifiable, string, string, object)"/>
         public static LocaleString GetLocaleString(this IIdentifiable identifiable, string key, string? format = null, bool continuous = true, Dictionary<string, object>? arguments = null)
-            => identifiable.GetLocaleKey(key).AsLocaleKey(format!, continuous, arguments.AddModIndicator(identifiable));
+            => identifiable.GetLocaleKey(key).AsModLocaleKey(identifiable, format!, continuous, arguments);
 
         /// <summary>
         /// Gets the formatted, localized message of the given locale <paramref name="key"/>
@@ -371,3 +396,5 @@ namespace MonkeyLoader.Resonite
             => (identifiable.TryFindNearestParent<Mod>(out var mod) ? mod : EngineInitHook.Mod).Id;
     }
 }
+
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/ButtonDelegateTooltipResolver.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/ButtonDelegateTooltipResolver.cs
@@ -72,11 +72,11 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
                 }
             }
 
-            arguments.Add(LocaleExtensions.ModLocaleStringIndicatorArgumentName, string.Empty);
             eventData.Label = localeKey.AsModLocaleKey(Mod, arguments: arguments);
+            eventData.ShouldCacheLabel = false; // The provided arguments' values may change between invocations
 
             if (TooltipConfig.Instance.EnableDebugButtonData)
-                Logger.Debug($"LocaleKey: {eventData.Label.Value.content}".Yield().Concat(eventData.Label.Value.arguments.Select(item => $"\"{item.Key}\" = \"{item.Value}\"")));
+                Logger.Debug($"LocaleKey: {localeKey}".Yield().Concat(arguments.Select(item => $"\"{item.Key}\" = \"{item.Value}\"")));
         }
     }
 }

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/ButtonDelegateTooltipResolver.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/ButtonDelegateTooltipResolver.cs
@@ -9,7 +9,9 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
     internal sealed class ButtonDelegateTooltipResolver : ResoniteCancelableEventHandlerMonkey<ButtonDelegateTooltipResolver, ResolveTooltipLabelEvent>
     {
         public override bool CanBeDisabled => true;
+
         public override int Priority => HarmonyLib.Priority.HigherThanNormal;
+
         public override bool SkipCanceled => true;
 
         protected override void Handle(ResolveTooltipLabelEvent eventData)
@@ -71,7 +73,7 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
             }
 
             arguments.Add(LocaleExtensions.ModLocaleStringIndicatorArgumentName, string.Empty);
-            eventData.Label = localeKey.AsLocaleKey(arguments: arguments);
+            eventData.Label = localeKey.AsModLocaleKey(Mod, arguments: arguments);
 
             if (TooltipConfig.Instance.EnableDebugButtonData)
                 Logger.Debug($"LocaleKey: {eventData.Label.Value.content}".Yield().Concat(eventData.Label.Value.arguments.Select(item => $"\"{item.Key}\" = \"{item.Value}\"")));

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/CommentTooltipResolver.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/CommentTooltipResolver.cs
@@ -47,8 +47,11 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
         /// <inheritdoc/>
         protected override void Handle(ResolveTooltipLabelEvent eventData)
         {
-            if (TryGetTooltipLabel(eventData.Button, out var label))
-                eventData.Label = label;
+            if (!TryGetTooltipLabel(eventData.Button, out var label))
+                return;
+
+            eventData.Label = label;
+            eventData.ShouldCacheLabel = true;
         }
 
         private static bool IsTooltipComment(Comment comment)

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/HyperlinkTooltipResolver.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/HyperlinkTooltipResolver.cs
@@ -84,8 +84,14 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
         /// <inheritdoc/>
         protected override void Handle(ResolveTooltipLabelEvent eventData)
         {
-            if (TryGetTooltipLabel(eventData.Button, out var label, eventData.Label))
-                eventData.Label = label;
+            if (!TryGetTooltipLabel(eventData.Button, out var label, eventData.Label))
+                return;
+
+            // Otherwise, keep prior caching
+            if (!eventData.HasLabel)
+                eventData.ShouldCacheLabel = true;
+
+            eventData.Label = label;
         }
     }
 }

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/ReferenceProxySourceTooltipResolver.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/ReferenceProxySourceTooltipResolver.cs
@@ -1,5 +1,6 @@
 ﻿using Elements.Core;
 using FrooxEngine;
+using FrooxEngine.UIX;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -20,15 +21,62 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
             if (button.Slot.GetComponent<ReferenceProxySource>() is not ReferenceProxySource proxySource)
                 return false;
 
-            // Slots, Users, (User)Components, SyncObjects themselves
-            if (proxySource.Reference.Target is Worker targetWorker)
+            var parentDevInterface = (button as Button)?.RectTransform?.Canvas.Slot.GetComponent<IDeveloperInterface>();
+
+            switch (parentDevInterface)
             {
-                label = $"Tooltip.{string.Join('.', GetAllNestedNames(targetWorker.WorkerType).Reverse())}";
+                case UserInspector:
+                case SceneInspector:
+                case WorkerInspector:
+                    return TryGetInspectorTooltipLabel(proxySource.Reference.Target, out label);
+
+                default:
+                    label = Mod.GetLocaleString("Tooltip.ReferenceProxySource", "target", proxySource.Reference.Target.GetReferenceLabel());
+                    return true;
+            }
+        }
+
+        protected override void Handle(ResolveTooltipLabelEvent eventData)
+        {
+            if (!TryGetTooltipLabel(eventData.Button, out var label))
+                return;
+
+            if (!TooltipConfig.Instance.EnableDebugButtonData && !label.Value.HasMessageInCurrent())
+                return;
+
+            eventData.Label = label;
+
+            if (TooltipConfig.Instance.EnableDebugButtonData)
+                Logger.Debug(() => $"LocaleKey: {eventData.Label.Value.content}");
+        }
+
+        private static IEnumerable<string> GetAllNestedNames(Type type)
+        {
+            yield return type.Name;
+
+            while (type.IsNested)
+            {
+                type = type.DeclaringType!;
+                yield return type.Name;
+            }
+        }
+
+        private static bool TryGetInspectorTooltipLabel(IWorldElement? target, [NotNullWhen(true)] out LocaleString? label)
+        {
+            label = null;
+
+            if (target is null)
+                return false;
+
+            // Slot, Users, (User)Components, SyncObjects themselves
+            if (target is Worker targetWorker)
+            {
+                label = $"Tooltip.{string.Join('.', GetAllNestedNames(targetWorker.WorkerType).Reverse())}".AsModLocaleKey(Mod);
                 return true;
             }
 
             // Any synchronized data owned by Workers
-            if (proxySource.Reference.Target is not SyncElement targetElement)
+            if (target is not SyncElement targetElement)
                 return false;
 
             var nesting = 0;
@@ -49,29 +97,14 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
             if (parentWorker.GetSyncMemberFieldInfo(targetElement.Name) is not FieldInfo targetField)
                 return false;
 
+            var typeIdentity = string.Join('.', GetAllNestedNames(targetField.DeclaringType!).Reverse());
+
             label = (nesting is 0
-                ? $"Tooltip.{string.Join('.', GetAllNestedNames(targetField.DeclaringType!).Reverse())}.{targetElement.Name}"
-                : $"Tooltip.{string.Join('.', GetAllNestedNames(targetField.DeclaringType!).Reverse())}.{targetElement.Name}.{string.Join('.', Enumerable.Repeat("Item", nesting))}"
+                ? $"Tooltip.{typeIdentity}.{targetElement.Name}"
+                : $"Tooltip.{typeIdentity}.{targetElement.Name}.{string.Join('.', Enumerable.Repeat("Item", nesting))}"
                 ).AsModLocaleKey(Mod);
 
             return true;
-        }
-
-        protected override void Handle(ResolveTooltipLabelEvent eventData)
-        {
-            if (TryGetTooltipLabel(eventData.Button, out var label))
-                eventData.Label = label;
-        }
-
-        private static IEnumerable<string> GetAllNestedNames(Type type)
-        {
-            yield return type.Name;
-
-            while (type.IsNested)
-            {
-                type = type.DeclaringType!;
-                yield return type.Name;
-            }
         }
     }
 }

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/ReferenceProxySourceTooltipResolver.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/ReferenceProxySourceTooltipResolver.cs
@@ -14,9 +14,10 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
 
         public override bool SkipCanceled => true;
 
-        public static bool TryGetTooltipLabel(IButton button, [NotNullWhen(true)] out LocaleString? label)
+        public static bool TryGetTooltipLabel(IButton button, [NotNullWhen(true)] out LocaleString? label, out bool shouldCache)
         {
             label = null;
+            shouldCache = true;
 
             if (button.Slot.GetComponent<ReferenceProxySource>() is not ReferenceProxySource proxySource)
                 return false;
@@ -31,6 +32,7 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
                     return TryGetInspectorTooltipLabel(proxySource.Reference.Target, out label);
 
                 default:
+                    shouldCache = false;
                     label = Mod.GetLocaleString("Tooltip.ReferenceProxySource", "target", proxySource.Reference.Target.GetReferenceLabel());
                     return true;
             }
@@ -38,13 +40,14 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
 
         protected override void Handle(ResolveTooltipLabelEvent eventData)
         {
-            if (!TryGetTooltipLabel(eventData.Button, out var label))
+            if (!TryGetTooltipLabel(eventData.Button, out var label, out var shouldCache))
                 return;
 
             if (!TooltipConfig.Instance.EnableDebugButtonData && !label.Value.HasMessageInCurrent())
                 return;
 
             eventData.Label = label;
+            eventData.ShouldCacheLabel = shouldCache;
 
             if (TooltipConfig.Instance.EnableDebugButtonData)
                 Logger.Debug(() => $"LocaleKey: {eventData.Label.Value.content}");

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/ReferenceProxySourceTooltipResolver.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/ReferenceProxySourceTooltipResolver.cs
@@ -52,7 +52,7 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
             label = (nesting is 0
                 ? $"Tooltip.{string.Join('.', GetAllNestedNames(targetField.DeclaringType!).Reverse())}.{targetElement.Name}"
                 : $"Tooltip.{string.Join('.', GetAllNestedNames(targetField.DeclaringType!).Reverse())}.{targetElement.Name}.{string.Join('.', Enumerable.Repeat("Item", nesting))}"
-                ).AsLocaleKey();
+                ).AsModLocaleKey(Mod);
 
             return true;
         }

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/ResolveTooltipLabelEvent.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/ResolveTooltipLabelEvent.cs
@@ -47,6 +47,16 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
             }
         }
 
+        /// <summary>
+        /// Gets or sets whether the tooltip <see cref="Label">label</see> for this
+        /// <see cref="Button">button</see> should be cached by the <see cref="TooltipManager"/>.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if the <see cref="Label">label</see> should be cached by
+        /// the <see cref="TooltipManager"/>; otherwise, <see langword="false"/>.
+        /// </value>
+        public bool ShouldCacheLabel { get; set; } = true;
+
         internal ResolveTooltipLabelEvent(IButton button, ButtonEventData buttonEventData)
         {
             Button = button;

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/SlotRecordTooltipResolver.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/SlotRecordTooltipResolver.cs
@@ -1,0 +1,49 @@
+﻿using Elements.Core;
+using FrooxEngine;
+using FrooxEngine.UIX;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MonkeyLoader.Resonite.UI.Tooltips
+{
+    internal sealed class SlotRecordTooltipResolver : ResoniteCancelableEventHandlerMonkey<SlotRecordTooltipResolver, ResolveTooltipLabelEvent>
+    {
+        public override bool CanBeDisabled => true;
+
+        public override int Priority => HarmonyLib.Priority.HigherThanNormal + 2;
+
+        public override bool SkipCanceled => true;
+
+        public static bool TryGetTooltipLabel(IButton button, [NotNullWhen(true)] out LocaleString? label)
+        {
+            label = null;
+
+            if (button.Slot.GetComponent<SlotRecord>() is not SlotRecord slotRecord)
+                return false;
+
+            if (slotRecord.TargetSlot.Target is not Slot targetSlot)
+                return false;
+
+            var parentDevInterface = (button as Button)?.RectTransform?.Canvas.Slot.GetComponent<IDeveloperInterface>();
+
+            switch (parentDevInterface)
+            {
+                case SceneInspector:
+                case WorkerInspector:
+                    label = Mod.GetLocaleString("Tooltip.SlotRecord.Inspector");
+                    return true;
+
+                default:
+                    label = Mod.GetLocaleString("Tooltip.SlotRecord.Generic");
+                    return true;
+            }
+        }
+
+        protected override void Handle(ResolveTooltipLabelEvent eventData)
+        {
+            if (!TryGetTooltipLabel(eventData.Button, out var label))
+                return;
+
+            eventData.Label = label;
+        }
+    }
+}

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/SlotRecordTooltipResolver.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/SlotRecordTooltipResolver.cs
@@ -13,9 +13,10 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
 
         public override bool SkipCanceled => true;
 
-        public static bool TryGetTooltipLabel(IButton button, [NotNullWhen(true)] out LocaleString? label)
+        public static bool TryGetTooltipLabel(IButton button, [NotNullWhen(true)] out LocaleString? label, out bool shouldCache)
         {
             label = null;
+            shouldCache = true;
 
             if (button.Slot.GetComponent<SlotRecord>() is not SlotRecord slotRecord)
                 return false;
@@ -33,17 +34,19 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
                     return true;
 
                 default:
-                    label = Mod.GetLocaleString("Tooltip.SlotRecord.Generic");
+                    shouldCache = false;
+                    label = Mod.GetLocaleString("Tooltip.SlotRecord.Generic", "target", targetSlot.GetReferenceLabel());
                     return true;
             }
         }
 
         protected override void Handle(ResolveTooltipLabelEvent eventData)
         {
-            if (!TryGetTooltipLabel(eventData.Button, out var label))
+            if (!TryGetTooltipLabel(eventData.Button, out var label, out var shouldCache))
                 return;
 
             eventData.Label = label;
+            eventData.ShouldCacheLabel = shouldCache;
         }
     }
 }

--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/TooltipManager.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/TooltipManager.cs
@@ -268,7 +268,9 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
 
             if (!label.Value.isLocaleKey || label.Value.HasMessageInCurrent())
             {
-                RegisterLabelForButton(button, label.Value);
+                if (eventData.ShouldCacheLabel)
+                    RegisterLabelForButton(button, label.Value);
+
                 return true;
             }
 

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "Remora.Resonite.Sdk": "2.2.0"
+        "Remora.Resonite.Sdk": "2.3.0"
     }
 }


### PR DESCRIPTION
Fixes the [issue of ReferenceProxySource tooltips appearing for things that don't have an entry](https://discord.com/channels/901126079857692714/901129181453230130/1513273936656334991).
<img height="300" alt="Screenshot of problem" src="https://github.com/user-attachments/assets/afcb9a92-4be5-4583-bef5-bd3b10811c62" />


Adds a generic "grabs reference to ..." version of the tooltip outside of inspectors.