### PR TITLE
Add dropped grabbables to contextmenu generation event

### DIFF
--- a/MonkeyLoader.Resonite.Core/UI/ContextMenuPaginationExtensions.cs
+++ b/MonkeyLoader.Resonite.Core/UI/ContextMenuPaginationExtensions.cs
@@ -14,6 +14,27 @@ namespace MonkeyLoader.Resonite.UI
     {
         private static readonly ConditionalWeakTable<ContextMenu, PaginationInfo> _paginationInfosByContextMenu = [];
 
+        internal static Func<int> GetDefaultMaxItems { get; set; } = static () => 14;
+
+        internal static Func<bool> GetLimitContextMenuItems { get; set; } = static () => true;
+
+        /// <summary>
+        /// Gets the current default maximum number of non-pagination items to show per page, not including the paging buttons.<br/>
+        /// This means that up to <c>value + 2</c> non-pagination items will be displayed without pagination.
+        /// </summary>
+        /// <remarks>
+        /// This value may change between calls.
+        /// </remarks>
+        public static int DefaultMaxItems => GetDefaultMaxItems();
+
+        /// <summary>
+        /// Gets whether the number of items in the context menu should be limited and pagination buttons added for anything beyond that.
+        /// </summary>
+        /// <remarks>
+        /// This value may change between calls.
+        /// </remarks>
+        public static bool LimitContextMenuItems => GetLimitContextMenuItems();
+
         /// <inheritdoc cref="AddPagination(ContextMenu, int, int, out ContextMenuItem, out ContextMenuItem)"/>
         public static void AddPagination(this ContextMenu contextMenu, int maxItems, int currentPage = 0)
             => contextMenu.AddPagination(maxItems, currentPage, out _, out _);
@@ -43,6 +64,75 @@ namespace MonkeyLoader.Resonite.UI
                 throw new InvalidOperationException("Failed to add pagination!");
         }
 
+        /// <remarks>
+        /// This version automatically uses the <see cref="DefaultMaxItems">DefaultMaxItems</see> for pagination, if wanted by the user.
+        /// </remarks>
+        /// <inheritdoc cref="AddPagination(ContextMenu, int, int, out ContextMenuItem, out ContextMenuItem)"/>
+        public static void AddDefaultPagination(this ContextMenu contextMenu, int currentPage = 0)
+        {
+            if (LimitContextMenuItems)
+                contextMenu.AddPagination(DefaultMaxItems, currentPage, out _, out _);
+        }
+
+        /// <remarks>
+        /// This version automatically uses the <see cref="DefaultMaxItems">DefaultMaxItems</see> for pagination, if wanted by the user.
+        /// </remarks>
+        /// <inheritdoc cref="AddPagination(ContextMenu, int, int, out ContextMenuItem, out ContextMenuItem)"/>
+        public static void AddDefaultPagination(this ContextMenu contextMenu, int currentPage,
+            out ContextMenuItem? back, out ContextMenuItem? forward)
+        {
+            back = null;
+            forward = null;
+
+            if (LimitContextMenuItems)
+                contextMenu.AddPagination(DefaultMaxItems, currentPage, out back, out forward);
+        }
+
+        /// <remarks>
+        /// This version automatically uses the <see cref="DefaultMaxItems">DefaultMaxItems</see> for pagination, if wanted by the user.
+        /// </remarks>
+        /// <inheritdoc cref="TryAddPagination(ContextMenu, int, int)"/>
+        public static bool TryAddDefaultPagination(this ContextMenu contextMenu, int currentPage = 0)
+        {
+            if (!LimitContextMenuItems)
+                return false;
+
+            return contextMenu.TryAddPagination(DefaultMaxItems, currentPage);
+        }
+
+        /// <remarks>
+        /// This version automatically uses the <see cref="DefaultMaxItems">DefaultMaxItems</see> for pagination, if wanted by the user.
+        /// </remarks>
+        /// <inheritdoc cref="TryAddPagination(ContextMenu, int, int, out ContextMenuItem?, out ContextMenuItem?)"/>
+        public static bool TryAddDefaultPagination(this ContextMenu contextMenu, int currentPage,
+                [NotNullWhen(true)] out ContextMenuItem? back, [NotNullWhen(true)] out ContextMenuItem? forward)
+        {
+            back = null;
+            forward = null;
+
+            if (!LimitContextMenuItems)
+                return false;
+
+            return contextMenu.TryAddPagination(DefaultMaxItems, currentPage, out back, out forward);
+        }
+
+        /// <remarks>
+        /// This version automatically uses the <see cref="DefaultMaxItems">DefaultMaxItems</see> for pagination, if wanted by the user.
+        /// </remarks>
+        /// <inheritdoc cref="TryAddPagination(ContextMenu, ref int, ref int, bool, out ContextMenuItem?, out ContextMenuItem?)"/>
+        public static bool TryAddDefaultPagination(this ContextMenu contextMenu, out int maxItems, ref int currentPage, bool forceNew,
+            [NotNullWhen(true)] out ContextMenuItem? back, [NotNullWhen(true)] out ContextMenuItem? forward)
+        {
+            back = null;
+            forward = null;
+            maxItems = DefaultMaxItems;
+
+            if (!LimitContextMenuItems)
+                return false;
+
+            return contextMenu.TryAddPagination(ref maxItems, ref currentPage, forceNew, out back, out forward);
+        }
+
         /// <summary>
         /// Tries to add pagination with the given configuration to this context menu.<br/>
         /// If there already is pagination, nothing happens.
@@ -60,7 +150,7 @@ namespace MonkeyLoader.Resonite.UI
         /// <param name="currentPage">The page that should be shown from the start. Can be any integer value, even negative.</param>
         /// <inheritdoc cref="TryAddPagination(ContextMenu, ref int, ref int, bool, out ContextMenuItem?, out ContextMenuItem?)"/>
         public static bool TryAddPagination(this ContextMenu contextMenu, int maxItems, int currentPage,
-            [NotNullWhen(true)] out ContextMenuItem? back, [NotNullWhen(true)] out ContextMenuItem? forward)
+                [NotNullWhen(true)] out ContextMenuItem? back, [NotNullWhen(true)] out ContextMenuItem? forward)
             => contextMenu.TryAddPagination(ref maxItems, ref currentPage, false, out back, out forward);
 
         /// <summary>

--- a/MonkeyLoader.Resonite.Core/WorldElementExtensions.cs
+++ b/MonkeyLoader.Resonite.Core/WorldElementExtensions.cs
@@ -8,6 +8,121 @@ namespace MonkeyLoader.Resonite
     /// </summary>
     public static class WorldElementExtensions
     {
+        // These are only necessary because FrooxEngine doesn't have proper nullability annotations
+#pragma warning disable CS8621 // Nullability of reference types in return type doesn't match the target delegate (possibly because of nullability attributes).
+#pragma warning disable CS8631 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.
+#pragma warning disable CS8634 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'class' constraint.
+
+        /// <summary>
+        /// Filters out any <see cref="Delegate"/>s with non-static methods targeting
+        /// <see langword="null"/>, <see cref="IWorldElement.IsLocalElement">local</see>,
+        /// or <see cref="IWorldElement.IsRemoved">removed</see> <see cref="IWorldElement">world element</see>.
+        /// </summary>
+        /// <param name="delegate">The <see cref="Delegate"/> to filter.</param>
+        /// <returns>
+        /// The <see cref="Delegate"/> if it's a static method or targeting a
+        /// <see cref="IWorldElement.IsLocalElement">global</see>
+        /// and not <see cref="IWorldElement.IsRemoved">removed</see>
+        /// <see cref="IWorldElement">world element</see>; otherwise, <see langword="null"/>.
+        /// </returns>
+        public static Delegate? FilterGlobalWorldDelegate(this Delegate? @delegate)
+        {
+            if (@delegate is null)
+                return null;
+
+            if (@delegate.Method.IsStatic)
+                return @delegate;
+
+            if ((@delegate.Target as IWorldElement)!.FilterGlobalWorldElement() is not null)
+                return @delegate;
+
+            return null;
+        }
+
+        /// <summary>
+        /// <see cref="FilterGlobalWorldDelegate(Delegate?)">Filters</see> this sequence of <see cref="Delegate"/>s for any
+        /// non-static methods targeting <see langword="null"/>, <see cref="IWorldElement.IsLocalElement">local</see>,
+        /// or <see cref="IWorldElement.IsRemoved">removed</see> <see cref="IWorldElement">world elements</see>.
+        /// </summary>
+        /// <param name="delegates">The sequence of <see cref="Delegate"/>s to filter.</param>
+        /// <returns>
+        /// The sequence of <see cref="Delegate"/>s without any non-static methods targeting
+        /// <see langword="null"/>, <see cref="IWorldElement.IsLocalElement">local</see>,
+        /// or <see cref="IWorldElement.IsRemoved">removed</see> <see cref="IWorldElement">world elements</see>.
+        /// </returns>
+        public static IEnumerable<Delegate> FilterGlobalWorldDelegates(this IEnumerable<Delegate?> delegates)
+            => delegates.Select(FilterGlobalWorldDelegate).OfType<Delegate>();
+
+        /// <summary>
+        /// Filters out any <see cref="Delegate"/>s with non-static methods targeting
+        /// <see langword="null"/> or <see cref="IWorldElement.IsRemoved">removed</see>
+        /// <see cref="IWorldElement">world element</see>.
+        /// </summary>
+        /// <param name="delegate">The <see cref="Delegate"/> to filter.</param>
+        /// <returns>
+        /// The <see cref="Delegate"/> if it's a static method or targeting
+        /// a not <see cref="IWorldElement.IsRemoved">removed</see>
+        /// <see cref="IWorldElement">world element</see>; otherwise, <see langword="null"/>.
+        /// </returns>
+        public static Delegate? FilterWorldDelegate(this Delegate? @delegate)
+        {
+            if (@delegate is null)
+                return null;
+
+            if (@delegate.Method.IsStatic)
+                return @delegate;
+
+            if ((@delegate.Target as IWorldElement)!.FilterWorldElement() is not null)
+                return @delegate;
+
+            return null;
+        }
+
+        /// <summary>
+        /// <see cref="FilterWorldDelegate(Delegate?)">Filters</see> this sequence of <see cref="Delegate"/>s
+        /// for any non-static methods targeting <see langword="null"/> or
+        /// <see cref="IWorldElement.IsRemoved">removed</see> <see cref="IWorldElement">world elements</see>.
+        /// </summary>
+        /// <param name="delegates">The sequence of <see cref="Delegate"/>s to filter.</param>
+        /// <returns>
+        /// The sequence of <see cref="Delegate"/>s without any non-static methods targeting
+        /// <see langword="null"/> or <see cref="IWorldElement.IsRemoved">removed</see>
+        /// <see cref="IWorldElement">world elements</see>.
+        /// </returns>
+        public static IEnumerable<Delegate> FilterWorldDelegates(this IEnumerable<Delegate?> delegates)
+            => delegates.Select(FilterWorldDelegate).OfType<Delegate>();
+
+        /// <summary>
+        /// <see cref="FrooxEngine.WorldElementExtensions.FilterGlobalWorldElement{T}(T)">Filters</see>
+        /// this sequence for any <see langword="null"/>, <see cref="IWorldElement.IsLocalElement">local</see>,
+        /// or <see cref="IWorldElement.IsRemoved">removed</see> elements.
+        /// </summary>
+        /// <typeparam name="T">The type of the world elements.</typeparam>
+        /// <param name="elements">The sequence of world elements to filter.</param>
+        /// <returns>
+        /// The sequence of world elements without any <see langword="null"/>,
+        /// <see cref="IWorldElement.IsLocalElement">local</see>,
+        /// or <see cref="IWorldElement.IsRemoved">removed</see> ones.
+        /// </returns>
+        public static IEnumerable<T> FilterGlobalWorldElements<T>(this IEnumerable<T?> elements)
+            where T : class, IWorldElement
+            => elements.Select(FrooxEngine.WorldElementExtensions.FilterGlobalWorldElement).OfType<T>();
+
+        /// <summary>
+        /// <see cref="FrooxEngine.WorldElementExtensions.FilterWorldElement{T}(T)">Filters</see>
+        /// this sequence for any <see langword="null"/> or <see cref="IWorldElement.IsRemoved">removed</see> elements.
+        /// </summary>
+        /// <typeparam name="T">The type of the world elements.</typeparam>
+        /// <param name="elements">The sequence of world elements to filter.</param>
+        /// <returns>The sequence of world elements without any <see langword="null"/> or <see cref="IWorldElement.IsRemoved">removed</see> ones.</returns>
+        public static IEnumerable<T> FilterWorldElements<T>(this IEnumerable<T?> elements)
+            where T : class, IWorldElement
+            => elements.Select(FrooxEngine.WorldElementExtensions.FilterWorldElement).OfType<T>();
+
+#pragma warning restore CS8634 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'class' constraint.
+#pragma warning restore CS8631 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.
+#pragma warning restore CS8621 // Nullability of reference types in return type doesn't match the target delegate (possibly because of nullability attributes).
+
         /// <summary>
         /// Gets the allocating <see cref="User"/> of this <see cref="IWorldElement">world element</see>.
         /// </summary>

--- a/MonkeyLoader.Resonite.Integration/Events/GrabbableInfo.cs
+++ b/MonkeyLoader.Resonite.Integration/Events/GrabbableInfo.cs
@@ -1,0 +1,80 @@
+﻿using FrooxEngine;
+using System.Collections.Immutable;
+
+namespace MonkeyLoader.Resonite.Events
+{
+    /// <summary>
+    /// Represents a complete set of information about the <see cref="IGrabbable"/>s
+    /// that a <see cref="User"/> is or was holding.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="IValueSource">value</see> and <see cref="IReferenceSource">reference</see> sources'
+    /// <see cref="IValueSource.BoxedValue">boxed values</see> and
+    /// <see cref="IReferenceSource.UntypedReference">untyped references</see> respectively,
+    /// as well as the <see cref="IDelegateProxy">delegate proxies</see>'
+    /// <see cref="IDelegateProxy.UntypedDelegate">untyped delegates</see>
+    /// are collected, since they're usually ephemeral and get removed as soon as they're dropped.
+    /// All returned elements are automatically filtered to not contain any removed ones.
+    /// </remarks>
+    public sealed class GrabbableInfo
+    {
+        private readonly ImmutableArray<object> _boxedValues;
+        private readonly ImmutableArray<IGrabbable> _grabbables;
+
+        private readonly ImmutableArray<Delegate> _untypedDelegates;
+        private readonly ImmutableArray<IWorldElement> _untypedReferences;
+
+        /// <summary>
+        /// Gets an empty instance of the grabble info.
+        /// </summary>
+        public static GrabbableInfo Empty { get; } = new([]);
+
+        /// <summary>
+        /// Gets the <see cref="IValueSource.BoxedValue">boxed values</see> of the
+        /// <see cref="IValueSource"/>s that were found in the original <see cref="IGrabbable">grabbables</see>.
+        /// </summary>
+        public IEnumerable<object> BoxedValues => _boxedValues;
+
+        /// <summary>
+        /// Gets the non-removed <see cref="IGrabbable">grabbables</see> from the original ones.
+        /// </summary>
+        public IEnumerable<IGrabbable> Grabbables => _grabbables.FilterWorldElements();
+
+        /// <summary>
+        /// Gets the <see cref="Delegate"/>s with non-removed targets of the
+        /// <see cref="IDelegateProxy"/>s that were found in the original <see cref="IGrabbable">grabbables</see>.
+        /// </summary>
+        public IEnumerable<Delegate> UntypedDelegates => _untypedDelegates.FilterWorldDelegates();
+
+        /// <summary>
+        /// Gets the non-removed <see cref="IReferenceSource.UntypedReference">untyped references</see> of the
+        /// <see cref="IReferenceSource"/>s that were found in the original <see cref="IGrabbable">grabbables</see>.
+        /// </summary>
+        public IEnumerable<IWorldElement> UntypedReferences => _untypedReferences.FilterWorldElements();
+
+        /// <summary>
+        /// Creates a new instance of this class with the given original <paramref name="grabbables"/>.
+        /// </summary>
+        /// <param name="grabbables">The grabbables to process and cache the usually ephemeral information from.</param>
+        public GrabbableInfo(IEnumerable<IGrabbable> grabbables)
+        {
+            _grabbables = [.. grabbables.FilterWorldElements()];
+
+            _boxedValues = [.. _grabbables
+                .SelectMany(GetComponentsInChildren<IValueSource>)
+                .Select(static valueSource => valueSource.BoxedValue)];
+
+            _untypedDelegates = [ .._grabbables
+                .SelectMany(GetComponentsInChildren<IDelegateProxy>)
+                .Select(static delegateProxy => delegateProxy.UntypedDelegate)];
+
+            _untypedReferences = [ ..grabbables
+                .SelectMany(GetComponentsInChildren<IReferenceSource>)
+                .Select(static referenceSource => referenceSource.UntypedReference)];
+        }
+
+        private static List<T> GetComponentsInChildren<T>(IGrabbable grabbable)
+                where T : class, IComponent
+            => grabbable.Slot.GetComponentsInChildren<T>();
+    }
+}

--- a/MonkeyLoader.Resonite.Integration/UI/ContextMenus/ContextMenuInjector.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/ContextMenus/ContextMenuInjector.cs
@@ -11,6 +11,9 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
     {
         protected override bool OnLoaded()
         {
+            ContextMenuPaginationExtensions.GetDefaultMaxItems = static () => ContextMenusConfig.Instance.ContextMenuItemLimit;
+            ContextMenuPaginationExtensions.GetLimitContextMenuItems = static () => ContextMenusConfig.Instance.LimitContextMenuItems;
+
             ContextMenuItemsGenerationEvent.AddConcreteEvent<InspectorMemberActions>(static contextMenu => new InspectorMemberActionsMenuItemsGenerationEvent(contextMenu), true);
 
             ContextMenuItemsGenerationEvent.AddConcreteEvent(typeof(FieldDriveReceiver<>), DriveReceiverMenuItemsGenerationEvent.CreateForDriveReceiver);

--- a/MonkeyLoader.Resonite.Integration/UI/ContextMenus/ContextMenuInjector.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/ContextMenus/ContextMenuInjector.cs
@@ -1,5 +1,6 @@
 ﻿using FrooxEngine;
 using HarmonyLib;
+using MonkeyLoader.Logging;
 using MonkeyLoader.Resonite.UI.Inspectors;
 
 namespace MonkeyLoader.Resonite.UI.ContextMenus
@@ -21,6 +22,8 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
         [HarmonyPostfix]
         private static async Task<ContextMenu?> OpenContextMenuPostfixAsync(Task<ContextMenu?> __result)
         {
+            var lastDroppedGrabbables = InteractionHandlerContextMenuInjector.GetLastDroppedGrabbables(TimeSpan.FromMilliseconds(250));
+
             if (await __result.ConfigureAwait(false) is not ContextMenu __instance)
                 return null;
 
@@ -29,7 +32,7 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             __instance.RunSynchronouslyAsync(async () =>
             {
-                var eventData = ContextMenuItemsGenerationEvent.CreateFor(__instance);
+                var eventData = ContextMenuItemsGenerationEvent.CreateFor(__instance, lastDroppedGrabbables);
                 Logger.Info(() => $"Dispatching CM event: {eventData.GetType().CompactDescription()}");
 
                 // ContextMenuItemsGenerationEvent is a SubscribableBaseEvent and will trigger derived handlers
@@ -37,6 +40,21 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
 
                 if (ContextMenusConfig.Instance.LimitContextMenuItems)
                     eventData.ContextMenu.TryAddPagination(ContextMenusConfig.Instance.ContextMenuItemLimit);
+
+                if (!Logger.ShouldLog(LoggingLevel.Debug))
+                    return;
+
+                Logger.Debug(() => "Dropped grabbables:");
+                Logger.Debug(eventData.LastDroppedGrabbables.Grabbables.Select(item => item.ParentHierarchyToString()).ToArray());
+
+                Logger.Debug(() => "Dropped values:");
+                Logger.Debug(eventData.LastDroppedGrabbables.BoxedValues);
+
+                Logger.Debug(() => "Dropped references:");
+                Logger.Debug(eventData.LastDroppedGrabbables.UntypedReferences.Select(FieldExtensions.GetReferenceLabel));
+
+                Logger.Debug(() => "Dropped delegates:");
+                Logger.Debug(eventData.LastDroppedGrabbables.UntypedDelegates.Select(del => $"{del.Method.CompactDescription()} on {(del.Target as IWorldElement).GetReferenceLabel()}"));
             });
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 

--- a/MonkeyLoader.Resonite.Integration/UI/ContextMenus/ContextMenuItemsGenerationEvent.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/ContextMenus/ContextMenuItemsGenerationEvent.cs
@@ -1,6 +1,8 @@
 ﻿using FrooxEngine;
 using HarmonyLib;
 using MonkeyLoader.Events;
+using MonkeyLoader.Resonite.Events;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 
 namespace MonkeyLoader.Resonite.UI.ContextMenus
@@ -50,6 +52,17 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
         public bool IsContextMenuOpen => ContextMenu.MenuState != ContextMenu.State.Closed;
 
         /// <summary>
+        /// Gets the last dropped <see cref="IGrabbable">grabbables</see>
+        /// and the cached contents of their usually ephemeral elements.
+        /// </summary>
+        /// <remarks>
+        /// These are always the last <i>dropped</i> <see cref="IGrabbable">grabbables</see>.
+        /// If you want the items currently held by the summoning <see cref="FrooxEngine.InteractionHandler"/>, try accessing
+        /// <c><see cref="InteractionHandler">InteractionHandler</see>.<see cref="InteractionHandler.Grabber">Grabber</see>.<see cref="Grabber.GrabbedObjects">GrabbedObjects</see></c>.
+        /// </remarks>
+        public GrabbableInfo LastDroppedGrabbables { get; private set; } = GrabbableInfo.Empty;
+
+        /// <summary>
         /// Gets the <see cref="IWorldElement"/> that the <see cref="ContextMenu">ContextMenu</see> is being summoned by.
         /// </summary>
         public IWorldElement Summoner => SummonerCore;
@@ -73,8 +86,11 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
         /// <exception cref="ArgumentException">When the <paramref name="contextMenu"/>'s <see cref="Slot.ActiveUser">active</see> <see cref="User"/> is <see langword="null"/>.</exception>
         protected ContextMenuItemsGenerationEvent(ContextMenu contextMenu)
         {
-            ContextMenu = contextMenu ?? throw new ArgumentNullException(nameof(contextMenu));
-            SummoningUser = contextMenu.Slot.ActiveUser ?? throw new ArgumentException($"Active User was missing for Context Menu: {contextMenu.ParentHierarchyToString()}", nameof(contextMenu));
+            ContextMenu = contextMenu
+                ?? throw new ArgumentNullException(nameof(contextMenu));
+
+            SummoningUser = contextMenu.Slot.ActiveUser
+                ?? throw new ArgumentException($"Active User was missing for Context Menu: {contextMenu.ParentHierarchyToString()}", nameof(contextMenu));
         }
 
         /// <summary>
@@ -212,16 +228,17 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
         /// <see cref="ContextMenu.CurrentSummoner"/>, falling back to the concrete <see cref="ContextMenuItemsGenerationEvent{T}"/>.
         /// </remarks>
         /// <param name="summoningUser">The <see cref="User"/> that the <see cref="FrooxEngine.ContextMenu"/> is being summoned for.</param>
+        /// <param name="grabbableInfo">The contextual last dropped grabbables.</param>
         /// <exception cref="ArgumentNullException">When the <paramref name="summoningUser"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException">When the <paramref name="summoningUser"/>'s <see cref="ContextMenuExtensions.GetUserContextMenu">context menu</see> is <see langword="null"/>.</exception>
-        internal static ContextMenuItemsGenerationEvent CreateFor(User summoningUser)
+        internal static ContextMenuItemsGenerationEvent CreateFor(User summoningUser, GrabbableInfo grabbableInfo)
         {
             ArgumentNullException.ThrowIfNull(summoningUser);
 
             var contextMenu = summoningUser.GetUserContextMenu()
                 ?? throw new ArgumentException($"Context Menu was missing for User: {summoningUser}!", nameof(summoningUser));
 
-            return CreateFor(contextMenu);
+            return CreateFor(contextMenu, grabbableInfo);
         }
 
         /// <summary>
@@ -233,8 +250,10 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
         /// for the <c><paramref name="contextMenu"/>.<see cref="ContextMenu.CurrentSummoner">CurrentSummoner</see></c>,
         /// falling back to the concrete <see cref="ContextMenuItemsGenerationEvent{T}"/>.
         /// </remarks>
+        /// <param name="contextMenu">The <see cref="FrooxEngine.ContextMenu"/> being summoned.</param>
+        /// <param name="grabbableInfo">The contextual last dropped grabbables.</param>
         /// <inheritdoc cref="ContextMenuItemsGenerationEvent(ContextMenu)"/>
-        internal static ContextMenuItemsGenerationEvent CreateFor(ContextMenu contextMenu)
+        internal static ContextMenuItemsGenerationEvent CreateFor(ContextMenu contextMenu, GrabbableInfo grabbableInfo)
         {
             ArgumentNullException.ThrowIfNull(contextMenu);
 
@@ -270,7 +289,11 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
             }
 
             contextMenuConstructor ??= GetDefaultContextMenuConstructor(summonerType);
-            return contextMenuConstructor(contextMenu);
+
+            var itemsGenerationEvent = contextMenuConstructor(contextMenu);
+            itemsGenerationEvent.LastDroppedGrabbables = grabbableInfo;
+
+            return itemsGenerationEvent;
         }
 
         private static Func<ContextMenu, ContextMenuItemsGenerationEvent> GetDefaultContextMenuConstructor(Type summonerType)

--- a/MonkeyLoader.Resonite.Integration/UI/ContextMenus/ContextMenuItemsGenerationEvent.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/ContextMenus/ContextMenuItemsGenerationEvent.cs
@@ -188,7 +188,10 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
         /// </summary>
         /// <remarks>
         /// If <paramref name="options"/>.<see cref="ContextMenuOptions.keepPosition">keepPosition</see>
-        /// is <c>true</c> the last position will be kept instead.
+        /// is <c>true</c> the last position will be kept instead.<br/>
+        /// This will automatically <see cref="ContextMenuPaginationExtensions.TryAddPagination(ContextMenu, int, int)">
+        /// add pagination</see> to the opened ContextMenu if the user's
+        /// <see cref="ContextMenusConfig.LimitContextMenuItems">settings</see> call for it.
         /// </remarks>
         /// <param name="pointer">
         /// The slot that the <see cref="FrooxEngine.ContextMenu"/> will be centered at.<br/>
@@ -197,7 +200,15 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
         /// <param name="options">The additional options for opening the menu.</param>
         /// <returns>The opened <see cref="FrooxEngine.ContextMenu"/>, or <see langword="null"/> if it failed to open.</returns>
         public async Task<ContextMenu?> OpenContextMenuAsync(Slot pointer, ContextMenuOptions options = default)
-            => await ContextMenu.OpenMenu(Summoner, pointer, options) ? ContextMenu : null;
+        {
+            if (!await ContextMenu.OpenMenu(Summoner, pointer, options))
+                return null;
+
+            if (ContextMenusConfig.Instance.LimitContextMenuItems)
+                ContextMenu.TryAddPagination(ContextMenusConfig.Instance.ContextMenuItemLimit);
+
+            return ContextMenu;
+        }
 
         /// <summary>
         /// Opens the <see cref="SummoningUser">SummoningUser</see>'s <see cref="FrooxEngine.ContextMenu"/>

--- a/MonkeyLoader.Resonite.Integration/UI/ContextMenus/ContextMenusConfig.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/ContextMenus/ContextMenusConfig.cs
@@ -1,7 +1,5 @@
-﻿using FrooxEngine;
-using MonkeyLoader.Configuration;
+﻿using MonkeyLoader.Configuration;
 using MonkeyLoader.Resonite.Configuration;
-using MonkeyLoader.Resonite.DataFeeds.Settings;
 
 namespace MonkeyLoader.Resonite.UI.ContextMenus
 {

--- a/MonkeyLoader.Resonite.Integration/UI/ContextMenus/InteractionHandlerContextMenuInjector.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/ContextMenus/InteractionHandlerContextMenuInjector.cs
@@ -3,20 +3,50 @@ using FrooxEngine;
 using FrooxEngine.CommonAvatar;
 using FrooxEngine.UIX;
 using HarmonyLib;
+using MonkeyLoader.Logging;
+using MonkeyLoader.Resonite.Events;
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 
 using static FrooxEngine.InteractionHandler;
 
 namespace MonkeyLoader.Resonite.UI.ContextMenus
 {
+    [HarmonyPatch(typeof(InteractionHandler))]
     [HarmonyPatchCategory(nameof(InteractionHandlerContextMenuInjector))]
-    [HarmonyPatch(typeof(InteractionHandler), nameof(InteractionHandler.OpenContextMenu))]
     internal sealed class InteractionHandlerContextMenuInjector
         : ConfiguredResoniteAsyncEventSourceMonkey<InteractionHandlerContextMenuInjector, ContextMenusConfig, ContextMenuItemsGenerationEvent>
     {
+        private static readonly ConditionalWeakTable<InteractionHandler, LastDroppedEntry> _lastDroppedGrabbablesByHandler = [];
+
         public override bool CanBeDisabled => true;
+
+        internal static InteractionHandler? LastDroppingHandler { get; private set; }
+
+        internal static GrabbableInfo GetLastDroppedGrabbables(TimeSpan? sinceDropped = default)
+            => LastDroppingHandler is null ? GrabbableInfo.Empty : GetLastDroppedGrabbablesFrom(LastDroppingHandler, sinceDropped);
+
+        internal static GrabbableInfo GetLastDroppedGrabbablesFrom(InteractionHandler handler, TimeSpan? sinceDropped = default)
+        {
+            if (!_lastDroppedGrabbablesByHandler.TryGetValue(handler, out var lastDroppedEntry))
+                return GrabbableInfo.Empty;
+
+            if (sinceDropped.HasValue && (DateTime.UtcNow - lastDroppedEntry.DroppedAt) > sinceDropped.Value)
+                return GrabbableInfo.Empty;
+
+            return lastDroppedEntry.GrabbableInfo;
+        }
 
         private static LocaleString AsMenuLocaleKey(string key)
             => key.AsLocaleKey(continuous: false, null);
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(InteractionHandler.EndGrab))]
+        private static void EndGrabPrefix(InteractionHandler __instance)
+        {
+            _lastDroppedGrabbablesByHandler.AddOrUpdate(__instance, new() { GrabbableInfo = new(__instance.Grabber.GrabbedObjects) });
+            LastDroppingHandler = __instance;
+        }
 
         private static string GetPrettyInventoryPath()
         {
@@ -38,6 +68,7 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
                         ?? "Unknown";
 
         [HarmonyPrefix]
+        [HarmonyPatch(nameof(InteractionHandler.OpenContextMenu))]
         private static bool OpenContextMenuPrefix(InteractionHandler __instance, MenuOptions options, float? speedOverride)
         {
             // Sadly have to replace the whole implementation, as the juicy part is all inside an async lambda -
@@ -267,7 +298,7 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
                         break;
                 }
 
-                var eventData = ContextMenuItemsGenerationEvent.CreateFor(menu);
+                var eventData = ContextMenuItemsGenerationEvent.CreateFor(menu, GetLastDroppedGrabbablesFrom(__instance));
                 Logger.Info(() => $"Dispatching CM event: {eventData.GetType().CompactDescription()}");
 
                 // ContextMenuItemsGenerationEvent is a SubscribableBaseEvent and will trigger derived handlers
@@ -278,9 +309,31 @@ namespace MonkeyLoader.Resonite.UI.ContextMenus
 
                 // This must happen at the end, otherwise the context menu items will flicker when items are added
                 await __instance.PositionContextMenu(menu);
+
+                if (!Logger.ShouldLog(LoggingLevel.Debug))
+                    return;
+
+                Logger.Debug(() => "Dropped grabbables:");
+                Logger.Debug(eventData.LastDroppedGrabbables.Grabbables.Select(item => item.ParentHierarchyToString()).ToArray());
+
+                Logger.Debug(() => "Dropped values:");
+                Logger.Debug(eventData.LastDroppedGrabbables.BoxedValues);
+
+                Logger.Debug(() => "Dropped references:");
+                Logger.Debug(eventData.LastDroppedGrabbables.UntypedReferences.Select(FieldExtensions.GetReferenceLabel));
+
+                Logger.Debug(() => "Dropped delegates:");
+                Logger.Debug(eventData.LastDroppedGrabbables.UntypedDelegates.Select(del => $"{del.Method.CompactDescription()} on {(del.Target as IWorldElement).GetReferenceLabel()}"));
             });
 
             return false;
+        }
+
+        private sealed class LastDroppedEntry
+        {
+            public DateTime DroppedAt { get; } = DateTime.UtcNow;
+
+            public GrabbableInfo GrabbableInfo { get; init; } = GrabbableInfo.Empty;
         }
     }
 }

--- a/MonkeyLoader.Resonite.Integration/UI/ContextMenus/InteractionHandlerContextMenuInjector.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/ContextMenus/InteractionHandlerContextMenuInjector.cs
@@ -5,7 +5,6 @@ using FrooxEngine.UIX;
 using HarmonyLib;
 using MonkeyLoader.Logging;
 using MonkeyLoader.Resonite.Events;
-using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 
 using static FrooxEngine.InteractionHandler;


### PR DESCRIPTION
Also featuring some new Filter(Global)World(Element|Delegate)(s) extensions

This will make it possible to access dropped references from a custom context menu for drive receivers for example