### PR TITLE
Use object root of canvas in tooltip resolver

### DIFF
--- a/MonkeyLoader.Resonite.Integration/UI/Tooltips/ReferenceProxySourceTooltipResolver.cs
+++ b/MonkeyLoader.Resonite.Integration/UI/Tooltips/ReferenceProxySourceTooltipResolver.cs
@@ -22,7 +22,7 @@ namespace MonkeyLoader.Resonite.UI.Tooltips
             if (button.Slot.GetComponent<ReferenceProxySource>() is not ReferenceProxySource proxySource)
                 return false;
 
-            var parentDevInterface = (button as Button)?.RectTransform?.Canvas.Slot.GetComponent<IDeveloperInterface>();
+            var parentDevInterface = (button as Button)?.RectTransform?.Canvas.Slot.GetObjectRoot(false).GetComponent<IDeveloperInterface>();
 
             switch (parentDevInterface)
             {


### PR DESCRIPTION
Fixes custom inspectors when using VanillaTooltips, as some custom inspectors might not have the SceneInspector component on the same slot as the Canvas.